### PR TITLE
Fix bug with review form

### DIFF
--- a/hypha/apply/review/templates/review/review_form.html
+++ b/hypha/apply/review/templates/review/review_form.html
@@ -40,7 +40,7 @@
             </div>
         </div>
         {% if not has_submitted_review %}
-            <form id="review-form-edit" class="flex-1 max-w-3xl form form--scoreable" action="" method="post">
+            <form id="review-form-edit" class="flex-1 max-w-3xl form form--scoreable" action="" method="post" novalidate>
                 {% csrf_token %}
                 {% for hidden in form.hidden_fields %}
                     {{ hidden }}

--- a/hypha/static_src/javascript/application-form.js
+++ b/hypha/static_src/javascript/application-form.js
@@ -51,7 +51,7 @@
 
   // Block multiple form submits.
   form.addEventListener("submit", function () {
-    window.setTimeOut(function () {
+    window.setTimeout(function () {
       button.setAttribute("disabled", "disabled");
     });
   });

--- a/hypha/static_src/sass/components/_form.scss
+++ b/hypha/static_src/sass/components/_form.scss
@@ -368,7 +368,8 @@
     input[type="email"],
     input[type="number"],
     input[type="password"],
-    input[type="datetime-local"] {
+    input[type="datetime-local"],
+    .tox-tinymce {
       border: 2px solid variables.$color--error;
     }
   }


### PR DESCRIPTION
I believe the root cause of this issue is https://github.com/tinymce/tinymce/issues/2584.

When the review form has a field of type "Rich text field" (or "Score" which uses a rich text field too) marked as "required", then the following HTML will be generated (simplified):
```html
<textarea style="display: none" required>
```

In that situation, leaving such a field blank and clicking "submit" will trigger the browser's client-side validation and the browser will attempt to focus the field and display a "this field is required" indicator. But that fails because the field is not visible, and an error is logged in the console:

> An invalid form control with name='...' is not focusable.


To get around this issue, I added `novalidate` to the `<form>`, which is something that was already done on the review edit form, but for some reason not on the review submission form.

I've also added an extra css rule to highlight the actual rich text field when it has errors.