### PR TITLE
Remove projects requirement for application PDF download

### DIFF
--- a/hypha/apply/funds/views/submission_detail.py
+++ b/hypha/apply/funds/views/submission_detail.py
@@ -273,14 +273,6 @@ class SubmissionSealedView(DetailView):
 class SubmissionDetailPDFView(SingleObjectMixin, View):
     model = ApplicationSubmission
 
-    def get_object(self, queryset=None):
-        obj = super().get_object(queryset)
-
-        if not hasattr(obj, "project"):
-            raise Http404
-
-        return obj
-
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         pdf_page_settings = PDFPageSettings.load(request_or_site=request)

--- a/hypha/apply/funds/views/submission_detail.py
+++ b/hypha/apply/funds/views/submission_detail.py
@@ -278,7 +278,7 @@ class SubmissionDetailPDFView(SingleObjectMixin, View):
         pdf_page_settings = PDFPageSettings.load(request_or_site=request)
         content = draw_submission_content(self.object.output_text_answers())
         pdf = make_pdf(
-            title=self.object.title,
+            title=self.object.title_text_display,
             sections=[
                 {
                     "content": content,

--- a/hypha/apply/funds/views/submission_detail.py
+++ b/hypha/apply/funds/views/submission_detail.py
@@ -287,7 +287,8 @@ class SubmissionDetailPDFView(SingleObjectMixin, View):
                         self.object.stage,
                         self.object.page,
                         self.object.round,
-                        f"Lead: {self.object.lead}",
+                        # Removed for WTSH because it messes the layout and is not needed:
+                        # f"Lead: {self.object.lead}",
                     ],
                 },
             ],


### PR DESCRIPTION
The restriction was added alongside the feature
in commit 17d292f9e9775e37e4144b1a1ee7028d8fac29b0 but without any real explanation.
The PDF download appears to work fine without this check so it should be fine to remove it.