### PR TITLE
Change filename of submission PDF download

### DIFF
--- a/hypha/apply/funds/views/submission_detail.py
+++ b/hypha/apply/funds/views/submission_detail.py
@@ -297,5 +297,5 @@ class SubmissionDetailPDFView(SingleObjectMixin, View):
         return FileResponse(
             pdf,
             as_attachment=True,
-            filename=self.object.title + ".pdf",
+            filename=f"{self.object.public_id or self.object.id}_{self.object.title}.pdf",
         )


### PR DESCRIPTION
As requested by the client: they want the id to be part of the filename (and appear first, so that sorting the file list produces something useful).