### PR TITLE
Fix double sending of email when concept is approved

### DIFF
--- a/hypha/apply/activity/templates/messages/email/invited_to_proposal.html
+++ b/hypha/apply/activity/templates/messages/email/invited_to_proposal.html
@@ -4,7 +4,10 @@
 {% block content %}{# fmt:off #}
 {% blocktrans %}We’ve reviewed your Concept note and think it could be a good fit for {{ ORG_SHORT_NAME }} funding. We would like to invite you to submit a Proposal with more details about your project. You will receive a second email linking to a determination message with detailed feedback.{% endblocktrans %}
 
-{% blocktrans %}Please review our Proposal Guide at {{ ORG_GUIDE_URL }} to learn more about the information we’d like to see. In the proposal please also address the feedback we provided in the concept note determination.{% endblocktrans %}{% endblock %}
+{% comment "Disabled for WTSH" %}
+{% blocktrans %}Please review our Proposal Guide at {{ ORG_GUIDE_URL }} to learn more about the information we’d like to see. In the proposal please also address the feedback we provided in the concept note determination.{% endblocktrans %}
+{% endcomment %}
+{% endblock %}
 
 {% block more_info %}
 {% trans "Here is the link to start creating your proposal" %}: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -15,6 +15,7 @@ from wagtail.models import Site
 
 from hypha.apply.activity.messaging import MESSAGES, messenger
 from hypha.apply.activity.models import Activity
+from hypha.apply.determinations.options import ACCEPTED
 from hypha.apply.funds.models import ApplicationSubmission
 from hypha.apply.funds.workflows import DETERMINATION_OUTCOMES
 from hypha.apply.funds.workflows.models.stage import Concept
@@ -462,13 +463,16 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
                 code=REVIEW_DRAFT, related_obj=review
             )
 
-        messenger(
-            MESSAGES.DETERMINATION_OUTCOME,
-            request=self.request,
-            user=self.object.author,
-            source=self.object.submission,
-            related=self.object,
-        )
+        # WTSH workaround: prevent sending of Concept approval email notification
+        # since another email was already sent with perform_transition() above.
+        if self.object.submission.in_final_stage or self.object.outcome != ACCEPTED:
+            messenger(
+                MESSAGES.DETERMINATION_OUTCOME,
+                request=self.request,
+                user=self.object.author,
+                source=self.object.submission,
+                related=self.object,
+            )
 
         return HttpResponseRedirect(self.submission.get_absolute_url())
 


### PR DESCRIPTION
The `invited_to_proposal` email template was also amended to remove a paragraph that's not needed for us.