### PR TITLE
WG-23: Fix average review score logic to handle NA

### DIFF
--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -196,8 +196,13 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
         )
 
     @property
+    def score_is_NA(self):
+        scores = [self.form_data.get(field.id)[1] for field in self.score_fields]
+        return any(score == NA for score in scores)
+
+    @property
     def get_score_display(self):
-        return "{:.1f}".format(self.score) if self.score != NA else "-"
+        return "{:.1f}".format(self.score) if not self.score_is_NA else "-"
 
     def get_absolute_url(self):
         return reverse(

--- a/hypha/apply/review/templates/review/includes/review_button.html
+++ b/hypha/apply/review/templates/review/includes/review_button.html
@@ -11,4 +11,10 @@
             {% endif %}
         </a>
     {% endif %}
+    {% if request.user|can_review:submission and not request.user|has_draft:submission %}
+        <a href="{% url 'apply:submissions:reviews:abstain' submission_pk=submission.id %}"
+           class="btn btn-secondary">
+            {% trans "I abstain" %}
+        </a>
+    {% endif %}
 {% endif %}

--- a/hypha/apply/review/templates/review/review_abstain.html
+++ b/hypha/apply/review/templates/review/review_abstain.html
@@ -1,0 +1,50 @@
+{% extends "review/review_form.html" %}
+{% load i18n %}
+
+{% block content %}
+    <section class="flex relative gap-4 justify-between my-4" x-data="reviewScore">
+
+        {% if not has_submitted_review %}
+            <form id="review-form-abstain" class="flex-1 max-w-3xl form" action="" method="post" novalidate>
+                {% include "forms/includes/form_errors.html" with form=form %}
+                {% csrf_token %}
+
+                {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
+
+                {% for field in form.visible_fields %}
+                    {% if field.field %}
+                        {% include "forms/includes/field.html" %}
+                    {% else %}
+                        <div class="max-w-none field-block prose">
+                            <div>
+                                {{ field.block }}
+                            </div>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+
+                <div class="items-center mt-4 card-actions">
+                    <button class="btn btn-primary" type="submit" name="submit">
+                        {% trans "I abstain" %}
+                    </button>
+                </div>
+
+            </form>
+            <aside
+                x-cloak
+                x-show="showSubmission"
+                class="overflow-y-auto max-h-screen grow bg-base-200 card card-border lg:max-w-1/2"
+            >
+                <div
+                    class="card-body"
+                    hx-get="{% url 'funds:submissions:partial-answers' submission.id %}"
+                    hx-trigger="intersect once"
+                >
+                    <p>{% trans "Loading…" %}</p>
+                </div>
+            </aside>
+        {% else %}
+            <p>{% trans "You have already posted a review for this submission" %}</p>
+        {% endif %}
+    </section>
+{% endblock %}

--- a/hypha/apply/review/templatetags/review_tags.py
+++ b/hypha/apply/review/templatetags/review_tags.py
@@ -3,7 +3,6 @@ from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from ..models import MAYBE, NO, YES
-from ..options import NA
 
 register = template.Library()
 
@@ -58,7 +57,7 @@ def average_review_score(reviewers):
             for reviewer in reviewers
             if not reviewer.has_review
             and not reviewer.review.is_draft
-            and not reviewer.review.score == NA
+            and not reviewer.review.score_is_NA
         ]
         if len(scores) > 0:
             return _("Avg. score: {average}").format(

--- a/hypha/apply/review/urls.py
+++ b/hypha/apply/review/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    ReviewAbstainView,
     ReviewCreateOrUpdateView,
     ReviewDeleteView,
     ReviewDetailView,
@@ -16,6 +17,7 @@ urlpatterns = [
     path("reviews/<int:pk>/", ReviewDetailView.as_view(), name="review"),
     path("reviews/<int:pk>/delete/", ReviewDeleteView.as_view(), name="delete"),
     path("reviews/<int:pk>/edit/", ReviewEditView.as_view(), name="edit"),
+    path("abstain/", ReviewAbstainView.as_view(), name="abstain"),
     path("review/", ReviewCreateOrUpdateView.as_view(), name="form"),
     path(
         "review/opinion/<int:pk>/delete/",

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
+from django.forms.widgets import HiddenInput, MultiWidget
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.loader import get_template
@@ -20,7 +21,13 @@ from wagtail.blocks import RichTextBlock
 from hypha.apply.activity.messaging import MESSAGES, messenger
 from hypha.apply.funds.models import ApplicationSubmission, AssignedReviewers
 from hypha.apply.funds.workflows import INITIAL_STATE
-from hypha.apply.review.blocks import RecommendationBlock, RecommendationCommentsBlock
+from hypha.apply.review.blocks import (
+    RecommendationBlock,
+    RecommendationCommentsBlock,
+    ScoreFieldBlock,
+    ScoreFieldWithoutTextBlock,
+    VisibilityBlock,
+)
 from hypha.apply.review.forms import ReviewModelForm, ReviewOpinionForm
 from hypha.apply.stream_forms.models import BaseStreamForm
 from hypha.apply.todo.options import REVIEW_DRAFT
@@ -30,7 +37,7 @@ from hypha.apply.utils.image import generate_image_tag
 from hypha.apply.utils.views import CreateOrUpdateView
 
 from .models import Review, ReviewOpinion
-from .options import DISAGREE
+from .options import DISAGREE, MAYBE, NA
 
 
 def get_fields_for_stage(submission, user=None):
@@ -198,6 +205,48 @@ class ReviewCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
 
     def get_success_url(self):
         return self.submission.get_absolute_url()
+
+
+@method_decorator(login_required, name="dispatch")
+class ReviewAbstainView(ReviewCreateOrUpdateView):
+    template_name = "review/review_abstain.html"
+
+    def get_form(self):
+        form = super().get_form()
+
+        # In order to reuse as much of the existing review code as possible,
+        # we keep all the review fields around but hide them (by using a HiddenInput
+        # for their widget).
+        # We also provide initial data for the mandatory "recommendation" field,
+        # and for the optional score fields if they exist.
+        for field in self.get_defined_fields():
+            form_field = form.fields[field.id]
+
+            if isinstance(field.block, RecommendationCommentsBlock):
+                form_field.initial = _("Abstain")
+            elif isinstance(field.block, RecommendationBlock):
+                form_field.initial = MAYBE
+            elif isinstance(field.block, ScoreFieldWithoutTextBlock):
+                # for ScoreFieldWithoutTextBlock the blank value is NA:
+                form_field.initial = ""
+            elif isinstance(field.block, ScoreFieldBlock):
+                form_field.initial = [_("Abstain"), NA]
+
+            if isinstance(field.block, VisibilityBlock):
+                pass
+            elif isinstance(form_field.widget, MultiWidget):
+                form_field.widget.widgets = [
+                    HiddenInput() for _ in form_field.widget.widgets
+                ]
+            else:
+                form_field.widget = HiddenInput()
+
+        return form
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = _("Abstain from review")
+        return context
 
 
 def review_workflow_actions(request, submission):

--- a/hypha/locale/de/LC_MESSAGES/django.po
+++ b/hypha/locale/de/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-20 08:51+0100\n"
+"POT-Creation-Date: 2025-11-25 14:43+0100\n"
 "PO-Revision-Date: 2025-11-20 09:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2323,6 +2323,7 @@ msgstr "Entwurf speichern"
 
 #: hypha/apply/determinations/templates/determinations/base_determination_form.html:108
 #: hypha/apply/funds/templates/funds/comments.html:108
+#: hypha/apply/review/templates/review/review_abstain.html:43
 #: hypha/apply/review/templates/review/review_form.html:107
 #: hypha/core/templates/components/dropdown-menu.html:91
 msgid "Loading…"
@@ -6528,6 +6529,16 @@ msgstr "Reviewer und Mitarbeiter"
 msgid "Add a review"
 msgstr "Eine Bewertung hinzufügen"
 
+#: hypha/apply/review/templates/review/includes/review_button.html:17
+#: hypha/apply/review/templates/review/review_abstain.html:28
+msgid "I abstain"
+msgstr "Ich enthalte mich"
+
+#: hypha/apply/review/templates/review/review_abstain.html:47
+#: hypha/apply/review/templates/review/review_form.html:111
+msgid "You have already posted a review for this submission"
+msgstr "Sie haben bereits eine Bewertung für diese Einreichung abgegeben"
+
 #: hypha/apply/review/templates/review/review_confirm_delete.html:4
 #: hypha/apply/review/templates/review/review_confirm_delete.html:8
 msgid "Deleting"
@@ -6580,10 +6591,6 @@ msgstr "Punktzahl:"
 msgid "Total Score:"
 msgstr "Gesamtpunktzahl:"
 
-#: hypha/apply/review/templates/review/review_form.html:111
-msgid "You have already posted a review for this submission"
-msgstr "Sie haben bereits eine Bewertung für diese Einreichung abgegeben"
-
 #: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:3
 msgid "Delete review opinion"
 msgstr "Löschen der Bewertungsmeinung"
@@ -6625,6 +6632,14 @@ msgstr "Review Entwurf aktualisieren"
 #: hypha/apply/review/views.py:149
 msgid "Create Review"
 msgstr "Erstellen Sie eine Bewertung"
+
+#: hypha/apply/review/views.py:226 hypha/apply/review/views.py:232
+msgid "Abstain"
+msgstr "Enthaltung"
+
+#: hypha/apply/review/views.py:247
+msgid "Abstain from review"
+msgstr "Enthalten Sie sich zur Bewertung"
 
 #: hypha/apply/stream_forms/blocks.py:114
 #: hypha/apply/stream_forms/blocks.py:217


### PR DESCRIPTION
This seems like it could be a bug in Hypha itself, but for now this workaround should do.

Instead of a full "abstain" action which might require a change to the data model, we can reuse the existing option of choosing a "N/A" score during determination (alongside a "Maybe" determination).

**Edit**: After feedback from Anja, I also added a new "[Abstain]" button which creates a review with default values (N/A score, "maybe" determination, fixed comment).

## Testing steps

1. Create a Fund/Round with a review form that has a "Score" field ("Punktzahl")
2. Submit an application
3. Review it once with a score of 5
4. Review it a second time with a score of "n/a choose not to answer"
5. Observe that the displayed score average is 5 (not 2.5 as previously)