### PR TITLE
WG-24: Show previous reviews on application page

### DIFF
--- a/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
@@ -55,6 +55,42 @@
     </section>
 {% endblock %}
 
+{% block previous_reviews %}
+    {% if object.previous %}
+        <section class="card card-border bg-base-100 shadow-xs">
+            <div class="card-body">
+                <h2 class="card-title">{% trans "Previous stage reviews" %}</h2>
+
+                <div
+                    hx-trigger="revealed, reviewerUpdated from:body"
+                    hx-get="{% url 'funds:submissions:partial-reviews-card' object.previous.id %}"
+                    hx-target="this"
+                >
+                    <div class="animate-pulse min-h-30">
+                        <div class="mb-3 w-full h-9 bg-base-300"></div>
+                        <div class="mb-1 w-full h-6 bg-base-300"></div>
+                        <div class="mb-3 w-full h-1 bg-base-300"></div>
+                        <div class="mb-3 w-20 h-6 bg-base-300"></div>
+                    </div>
+                </div>
+
+                <div class="card-actions">
+                    {% include 'review/includes/review_button.html' with submission=object.previous class="grow" %}
+
+                    {% if request.user.is_apply_staff and not object.previous.reviews.exists %}
+                        <a
+                            href="{% url 'apply:submissions:reviews:list' submission_pk=object.previous.id %}"
+                            class="btn btn-outline grow"
+                        >
+                            {% trans "View all" %}
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        </section>
+    {% endif %}
+{% endblock %}
+
 {% block screening_status %}
     <div hx-trigger="revealed" hx-get="{% url "funds:submissions:partial-screening-card" object.id %}"></div>
 {% endblock %}

--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -166,6 +166,9 @@
             {% block reviews %}
             {% endblock %}
 
+            {% block previous_reviews %}
+            {% endblock %}
+
             {% block flags %}
             {% endblock %}
 

--- a/hypha/apply/funds/templates/funds/applicationsubmission_reviewer_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_reviewer_detail.html
@@ -35,5 +35,25 @@
     </div>
 {% endblock %}
 
-{% block related %}
+{% block previous_reviews %}
+    {% if object.previous %}
+        <div class="card card-border bg-base-100 shadow-xs">
+            <div class="card-body">
+                <h2 class="card-title">{% trans "Previous stage reviews" %}</h2>
+
+                <div
+                    hx-trigger="revealed"
+                    hx-get="{% url 'funds:submissions:partial-reviews-card' object.previous.id %}"
+                    hx-target="this"
+                >
+                    <div class="animate-pulse min-h-30">
+                        <div class="mb-3 w-full h-9 bg-base-300"></div>
+                        <div class="mb-1 w-full h-6 bg-base-300"></div>
+                        <div class="mb-3 w-full h-1 bg-base-300"></div>
+                        <div class="mb-3 w-20 h-6 bg-base-300"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Testing steps

(This is easiest to do by using the "switch user" feature and switch between 2 users: Admin, Applicant, and Reviewer)

1. [Admin] Create a Fund/Round with a 2-stage workflow ("Concept & Proposal" for example)
2. [Applicant] Submit an application
3. [Admin] Move application to the "External Review" phase/status
4. [Reviewer] Submit a review
5. [Admin] Move application to the next stage (Proposal), and to the "External Review" phase/status
6. [Reviewer] Open the application page, observe that you can see a new "Previous stage reviews" box in the sidebar
7. [Reviewer] Also observe that there's a "Related submissions" box (bottom) with a link to the application's previous stage (Concept).

## Screenshots

<details><summary>Sidebar box</summary>

<img width="326" height="283" alt="Screenshot 2025-11-19 at 16-05-12 Second application (#6)" src="https://github.com/user-attachments/assets/f69f0491-3c23-4552-8484-6041fc6062be" />


</details> 