### PR TITLE
WG-27: Update translations (de)

### DIFF
--- a/hypha/locale/de/LC_MESSAGES/django.po
+++ b/hypha/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,19 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# This file was generated from messages_updated.xlsx
 msgid ""
 msgstr ""
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-30 11:46+0200\n"
-"PO-Revision-Date: 2025-04-30 12:12+0200\n"
+"POT-Creation-Date: 2025-11-20 08:51+0100\n"
+"PO-Revision-Date: 2025-11-20 09:24+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: de\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: xls2po 3.3\n"
+"Generated-By: xls2po 3.3\n"
+"X-Generator: Poedit 3.7\n"
 
 #: hypha/apply/activity/adapters/activity_feed.py:28
 #, python-brace-format
@@ -87,122 +88,121 @@ msgstr "Genehmigung angefordert"
 #: hypha/apply/activity/adapters/activity_feed.py:61
 #: hypha/apply/determinations/options.py:12
 #: hypha/apply/projects/templates/application_projects/paf_export.html:22
-#: hypha/apply/projects/utils.py:76
+#: hypha/apply/projects/utils.py:87
 msgid "Approved"
 msgstr "Genehmigt"
 
+#: hypha/apply/activity/adapters/activity_feed.py:62
+msgid "requested changes for acceptance"
+msgstr "geforderte Änderungen zur Annahme"
+
 #: hypha/apply/activity/adapters/activity_feed.py:63
-#, python-brace-format
-msgid "requested changes for acceptance: \"{comment}\""
-msgstr "beantragte Änderungen zur Annahme: \"{comment}\""
-
-#: hypha/apply/activity/adapters/activity_feed.py:65
 msgid "Submitted Contract Documents"
-msgstr "Eingereichte Vertragsdokumente"
+msgstr "Übertragene Vertragsdokumente"
 
-#: hypha/apply/activity/adapters/activity_feed.py:66
+#: hypha/apply/activity/adapters/activity_feed.py:64
 #, python-brace-format
 msgid "Uploaded a {contract.state} contract"
-msgstr "Haben ein {contract.state} Vertrag hochgeladen"
+msgstr "{contract.state} -Vertrag hochgeladen"
 
-#: hypha/apply/activity/adapters/activity_feed.py:67
+#: hypha/apply/activity/adapters/activity_feed.py:65
 msgid "Approved contract"
 msgstr "Genehmigter Vertrag"
 
-#: hypha/apply/activity/adapters/activity_feed.py:69
-#: hypha/apply/projects/views/payment.py:251
+#: hypha/apply/activity/adapters/activity_feed.py:67
+#: hypha/apply/projects/views/payment.py:274
 msgid "Invoice added"
 msgstr "Rechnung hinzugefügt"
 
-#: hypha/apply/activity/adapters/activity_feed.py:70
+#: hypha/apply/activity/adapters/activity_feed.py:68
 msgid "Submitted a report"
-msgstr "Haben einen Bericht eingereicht"
+msgstr "Bericht eingereicht"
 
-#: hypha/apply/activity/adapters/activity_feed.py:73
+#: hypha/apply/activity/adapters/activity_feed.py:71
 #: hypha/apply/activity/options.py:65
 msgid "disabled reporting"
-msgstr "Berichterstellung deaktiviert"
+msgstr "Reporting deaktiviert"
+
+#: hypha/apply/activity/adapters/activity_feed.py:75
+msgid "archived this submission"
+msgstr "Diese Einsendung archiviert"
+
+#: hypha/apply/activity/adapters/activity_feed.py:76
+msgid "un-archived this submission"
+msgstr "Diese Einsendung nicht archiviert"
 
 #: hypha/apply/activity/adapters/activity_feed.py:77
-msgid "archived this submission"
-msgstr "hat diese Einreichung archiviert"
-
-#: hypha/apply/activity/adapters/activity_feed.py:78
-msgid "un-archived this submission"
-msgstr "entarchiviert diese Einreichung"
-
-#: hypha/apply/activity/adapters/activity_feed.py:79
 msgid "deleted an invoice"
-msgstr "hat eine Rechnung gelöscht"
+msgstr "Eine Rechnung gelöscht"
 
-#: hypha/apply/activity/adapters/activity_feed.py:135
-#: hypha/apply/funds/views/submission_edit.py:640
+#: hypha/apply/activity/adapters/activity_feed.py:133
+#: hypha/apply/funds/views/submission_edit.py:630
 msgid "Reviewers updated."
 msgstr "Reviewer aktualisiert."
 
-#: hypha/apply/activity/adapters/activity_feed.py:137
+#: hypha/apply/activity/adapters/activity_feed.py:135
 #: hypha/apply/activity/adapters/activity_feed.py:295
 #: hypha/apply/activity/adapters/slack.py:240
 msgid "Added:"
-msgstr "Hinzugefügt:"
+msgstr "Angefügt:"
 
-#: hypha/apply/activity/adapters/activity_feed.py:141
+#: hypha/apply/activity/adapters/activity_feed.py:139
 #: hypha/apply/activity/adapters/activity_feed.py:299
 #: hypha/apply/activity/adapters/slack.py:244
 msgid "Removed:"
 msgstr "Entfernt:"
 
-#: hypha/apply/activity/adapters/activity_feed.py:147
+#: hypha/apply/activity/adapters/activity_feed.py:145
 msgid "Batch reviewers updated:"
-msgstr "Batch reviewers updated:"
+msgstr "Batch-Reviewer aktualisiert:"
 
-#: hypha/apply/activity/adapters/activity_feed.py:150
+#: hypha/apply/activity/adapters/activity_feed.py:148
 #, python-brace-format
 msgid "{user} as {name}."
 msgstr "{user} als {name}."
 
-#: hypha/apply/activity/adapters/activity_feed.py:169
+#: hypha/apply/activity/adapters/activity_feed.py:167
 #, python-brace-format
 msgid "Successfully deleted submissions: {title}"
-msgstr "Erfolgreich gelöschte Einreichungen: {title}"
+msgstr "Erfolgreich gelöschte Einsendungen: {title}"
 
-#: hypha/apply/activity/adapters/activity_feed.py:178
+#: hypha/apply/activity/adapters/activity_feed.py:176
 #, python-brace-format
 msgid "Successfully archived submissions: {title}"
-msgstr "Erfolgreich archivierte Einreichungen: {title}"
+msgstr "Erfolgreich archivierte Einsendungen: {title}"
 
-#: hypha/apply/activity/adapters/activity_feed.py:191
+#: hypha/apply/activity/adapters/activity_feed.py:189
 #, python-brace-format
 msgid ""
 "Successfully updated status to {invoice_status} for invoices: "
 "{invoice_numbers}"
 msgstr ""
-"Status erfolgreich zu {invoice_status} für Rechnungen aktualisiert: "
+"Status erfolgreich auf {invoice_status} für Rechnungen aktualisiert: "
 "{invoice_numbers}"
 
-#: hypha/apply/activity/adapters/activity_feed.py:208
+#: hypha/apply/activity/adapters/activity_feed.py:206
 msgid "assigned Project form to {}"
-msgstr "weisen Projektform zu {}"
+msgstr "dem Projektformular {} zugewiesen"
 
-#: hypha/apply/activity/adapters/activity_feed.py:214
+#: hypha/apply/activity/adapters/activity_feed.py:212
 #, python-brace-format
 msgid "removed the task {task.code} for {source} from the task list"
-msgstr "entfernte die Aufgabe {task.code} von {source} aus der Aufgabenliste"
+msgstr "entfernte die Aufgabe {task.code} für {source} aus der Aufgabenliste"
 
-#: hypha/apply/activity/adapters/activity_feed.py:219
+#: hypha/apply/activity/adapters/activity_feed.py:217
 #, python-brace-format
 msgid ""
 "removed the task {task.code} for {source} from whole team's{user_groups} "
 "task list."
 msgstr ""
-"entfernte die Aufgabe {task.code} von {source} aus der gesamten "
-"Aufgabenliste des Teams{user_groups}."
+"Die Aufgabe {task.code} für {source} aus der gesamten Team-Aufgabenliste "
+"{user_groups} entfernt."
 
-#: hypha/apply/activity/adapters/activity_feed.py:232
-#: hypha/apply/activity/adapters/activity_feed.py:264
+#: hypha/apply/activity/adapters/activity_feed.py:230
+#: hypha/apply/activity/adapters/activity_feed.py:263
 #, python-brace-format
 msgid "Progressed from {old_display} to {new_display}"
-msgstr "Von {old_display} auf {new_display} fortgeschritten"
+msgstr "Fortschritt von {old_display} zu {new_display}"
 
 #: hypha/apply/activity/adapters/activity_feed.py:293
 msgid "Partners updated."
@@ -214,95 +214,102 @@ msgid ""
 "Updated reporting frequency. New schedule is: {new_schedule} starting on "
 "{schedule_start}"
 msgstr ""
-"Aktualisierte Berichtshäufigkeit. Der neue Zeitplan lautet: {new_schedule} "
-"und beginnt am {schedule_start}"
+"Aktualisierte Berichtsfrequenz. Der neue Zeitplan lautet: {new_schedule} "
+"beginnend am {schedule_start}"
 
 #: hypha/apply/activity/adapters/activity_feed.py:317
 #, python-brace-format
 msgid "Updated Invoice status to: {invoice_status}."
-msgstr "Rechnungsstatus aktualisiert auf: {invoice_status}."
+msgstr "Rechnungsstatus aktualisiert zu: {invoice_status}."
 
 #: hypha/apply/activity/adapters/activity_feed.py:366
 #, python-brace-format
 msgid "Updated screening decision from \"{old_status}\" to \"{new_status}\""
 msgstr ""
-"Aktualisierte Screening-Entscheidung von \"{old_status}\" zu \"{new_status}\""
+"Aktualisierte Screening-Entscheidung von \"{old_status}\" auf \"{new_status}"
+"\""
 
 #: hypha/apply/activity/adapters/activity_feed.py:369
 #, python-brace-format
 msgid "Added screening decision to \"{new_status}\""
-msgstr "Überprüfungs-Entscheidung zu \"{new_status}\" hinzugefügt"
+msgstr "Screening-Entscheidung zu \"{new_status}\" hinzugefügt."
 
 #: hypha/apply/activity/adapters/activity_feed.py:373
 #, python-brace-format
 msgid "Removed \"{old_status}\" screening decision."
-msgstr "Entfernt \"{old_status}\"-Überprüfungsentscheidung."
+msgstr "\"{old_status}\"-Screening-Entscheidung entfernt."
 
-#: hypha/apply/activity/adapters/emails.py:79
+#: hypha/apply/activity/adapters/emails.py:93
 #, python-brace-format
 msgid "Application ready to review: {source.title_text_display}"
-msgstr "Antrag bereit zur Bewertung: {source.title_text_display}"
+msgstr "Einreichung bereit für Review: {source.title_text_display}"
 
-#: hypha/apply/activity/adapters/emails.py:85
+#: hypha/apply/activity/adapters/emails.py:99
 msgid "Multiple applications are now ready for your review"
-msgstr "Mehrere Anträge sind jetzt für Ihre Bewertung bereit"
+msgstr "Mehrere Einreichungen sind jetzt zur Überprüfung bereit"
 
-#: hypha/apply/activity/adapters/emails.py:88
+#: hypha/apply/activity/adapters/emails.py:102
 #, python-brace-format
 msgid "Reminder: Application ready to review: {source.title_text_display}"
-msgstr "Erinnerung: Antrag bereit zur Bewertung: {source.title_text_display}"
+msgstr "Erinnerung: Einreichung zur Prüfung: {source.title_text_display}"
 
-#: hypha/apply/activity/adapters/emails.py:94
+#: hypha/apply/activity/adapters/emails.py:105
+msgid "You are invited as a co-applicant"
+msgstr "Du bist als Mitantragsteller eingeladen"
+
+#: hypha/apply/activity/adapters/emails.py:110
 #, python-brace-format
 msgid "Project is waiting for approval: {source.title}"
-msgstr "Projekt wartet auf Genehmigung: {source.title}"
+msgstr "Projekt wartet auf Prüfung: {source.title}"
 
-#: hypha/apply/activity/adapters/emails.py:98
+#: hypha/apply/activity/adapters/emails.py:114
 #, python-brace-format
 msgid "Contract uploaded for the project: {source.title}"
-msgstr "Vertrag hochgeladen für das Projekt: {source.title}"
+msgstr "Vertrag für das Projekt hochgeladen: {source.title}"
 
-#: hypha/apply/activity/adapters/emails.py:103
+#: hypha/apply/activity/adapters/emails.py:119
 #, python-brace-format
 msgid "Contract Documents required approval for the project: {source.title}"
 msgstr ""
-"Vertragsdokumente benötigen eine Genehmigung für das Projekt: {source.title}"
+"Für das Projekt erforderliche Vertragsdokumente wurde genehmigt: "
+"{source.title}"
 
-#: hypha/apply/activity/adapters/emails.py:113
+#: hypha/apply/activity/adapters/emails.py:129
 #, python-brace-format
 msgid "Project is waiting for the contract: {source.title}"
 msgstr "Das Projekt wartet auf den Vertrag: {source.title}"
 
-#: hypha/apply/activity/adapters/emails.py:117
+#: hypha/apply/activity/adapters/emails.py:133
 #, python-brace-format
 msgid "Project is ready for invoicing: {source.title}"
-msgstr "Projekt ist bereit für die Rechnungsstellung: {source.title}"
-
-#: hypha/apply/activity/adapters/emails.py:121
-#, python-brace-format
-msgid "Project status has changed to {project_status}: {source.title}"
-msgstr "Projektstatus wurde geändert in {project_status}: {source.title}"
-
-#: hypha/apply/activity/adapters/emails.py:127
-msgid "Project has been rejected, please update and resubmit"
-msgstr "Projekt wurde abgelehnt, bitte aktualisieren und erneut einreichen"
-
-#: hypha/apply/activity/adapters/emails.py:130
-#, python-brace-format
-msgid "Project documents are ready to be assigned for approval: {source.title}"
-msgstr ""
-"Projektdokumente sind bereit, um für die Genehmigung zugewiesen zu werden: "
-"{source.title}"
+msgstr "Projekt ist bereit zur Rechnungsstellung: {source.title}"
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, python-brace-format
-msgid "Your application to {org_long_name}: {source.title_text_display}"
-msgstr "Ihre Bewerbung bei {org_long_name}: {source.title_text_display}"
+msgid "Project status has changed to {project_status}: {source.title}"
+msgstr ""
+"Der Projektstatus hat sich geändert zu {project_status}: {source.title}"
 
-#: hypha/apply/activity/adapters/emails.py:140
+#: hypha/apply/activity/adapters/emails.py:143
+msgid "Project has been rejected, please update and resubmit"
+msgstr "Projekt wurde abgelehnt, bitte aktualisieren und erneut einreichen"
+
+#: hypha/apply/activity/adapters/emails.py:146
+#, python-brace-format
+msgid "Project documents are ready to be assigned for approval: {source.title}"
+msgstr ""
+"Projektdokumente sind bereit, zur Genehmigung zugewiesen zu werden: "
+"{source.title}"
+
+#: hypha/apply/activity/adapters/emails.py:153
+#, python-brace-format
+msgid "Your application to {org_long_name}: {source.title_text_display}"
+msgstr "Deine Bewerbung bei {org_long_name}: {source.title_text_display}"
+
+#: hypha/apply/activity/adapters/emails.py:156
 #, python-brace-format
 msgid "Your {org_long_name} Project: {source.title}"
-msgstr "Ihr {org_long_name}-Projekt: {source.title}"
+msgstr "Dein {org_long_name}-Projekt: {source.title}"
 
 #: hypha/apply/activity/adapters/slack.py:31
 #, python-brace-format
@@ -310,7 +317,7 @@ msgid ""
 "A new submission has been submitted for {source.page.title}: <{link}|"
 "{source.title_text_display}> by {user}"
 msgstr ""
-"Eine neue Einreichung wurde für {source.page.title} eingereicht: <{link}|"
+"Ein neuer Beitrag wurde für {source.page.title} eingereicht: <{link}|"
 "{source.title_text_display}> von {user}"
 
 #: hypha/apply/activity/adapters/slack.py:34
@@ -320,7 +327,7 @@ msgid ""
 "{old_lead} to {source.lead} by {user}"
 msgstr ""
 "Der Lead von <{link}|{source.title_text_display}> wurde von {old_lead} auf "
-"{source.lead} durch {user} aktualisiert"
+"{source.lead} von {user} aktualisiert"
 
 #: hypha/apply/activity/adapters/slack.py:38
 #, python-brace-format
@@ -328,29 +335,29 @@ msgid ""
 "A new {comment.visibility} comment has been posted on <{link}|{source.title}"
 "> by {user}"
 msgstr ""
-"Ein neuer {comment.visibility} Kommentar wurde auf <{link}|{source.title}> "
-"von {user} veröffentlicht"
+"Ein neuer Kommentar {comment.visibility} wurde auf <{link}|{source.title}> "
+"von {user} gepostet"
 
 #: hypha/apply/activity/adapters/slack.py:41
 #: hypha/apply/activity/adapters/slack.py:44
 #, python-brace-format
 msgid "{user} has edited <{link}|{source.title_text_display}>"
-msgstr "{user} hat <{link}|{source.title_text_display}> bearbeitet"
+msgstr "{user} hat <{link}|{source.title_text_display}bearbeitet>"
 
 #: hypha/apply/activity/adapters/slack.py:49
 #, python-brace-format
 msgid "{user} has updated the partners on <{link}|{source.title_text_display}>"
 msgstr ""
-"{user} hat die Partner auf <{link}|{source.title_text_display}> aktualisiert"
+"{user} hat die Partner auf <{link}|{source.title_text_display}aktualisiert>"
 
 #: hypha/apply/activity/adapters/slack.py:52
 #, python-brace-format
 msgid ""
 "{user} has updated the status of <{link}|{source.title_text_display}>: "
-"{old_phase.display_name} → {source.phase}"
+"{source.phase.display_name} → {new_phase.display_name}"
 msgstr ""
 "{user} hat den Status von <{link}|{source.title_text_display}> aktualisiert: "
-"{old_phase.display_name} → {source.phase}"
+"{source.phase.display_name} → {new_phase.display_name}"
 
 #: hypha/apply/activity/adapters/slack.py:58
 #, python-brace-format
@@ -358,7 +365,7 @@ msgid ""
 "A proposal has been submitted for review: <{link}|{source.title_text_display}"
 ">"
 msgstr ""
-"Ein Vorschlag wurde zur Bewertung eingereicht: <{link}|"
+"Ein Vorschlag wurde zur Prüfung eingereicht: <{link}|"
 "{source.title_text_display}>"
 
 #: hypha/apply/activity/adapters/slack.py:61
@@ -367,8 +374,8 @@ msgid ""
 "<{link}|{source.title_text_display}> by {source.user} has been invited to "
 "submit a proposal"
 msgstr ""
-"<{link}|{source.title_text_display}> von {source.user} wurde eingeladen, ein "
-"Angebot einzureichen"
+"<{link}|{source.title_text_display}> von {source.user} wurde eingeladen, "
+"einen Vorschlag einzureichen"
 
 #: hypha/apply/activity/adapters/slack.py:64
 #, python-brace-format
@@ -385,7 +392,7 @@ msgstr ""
 msgid ""
 "{user} has opened the sealed submission: <{link}|{source.title_text_display}>"
 msgstr ""
-"{user} hat die gesperrte Einreichung geöffnet: <{link}|"
+"{user} hat die versiegelte Einreichung geöffnet: <{link}|"
 "{source.title_text_display}>"
 
 #: hypha/apply/activity/adapters/slack.py:71
@@ -394,7 +401,7 @@ msgid ""
 "{user} {opinion.opinion_display}s with {opinion.review.author}s review of "
 "<{link}|{source.title_text_display}>"
 msgstr ""
-"{user} {opinion.opinion_display}s mit {opinion.review.author}s Bewertung von "
+"{user} {opinion.opinion_display}s mit {opinion.review.author}s Rezension von "
 "<{link}|{source.title_text_display}>"
 
 #: hypha/apply/activity/adapters/slack.py:74
@@ -408,8 +415,8 @@ msgid ""
 "{user} has deleted {review.author} review for <{link}|"
 "{source.title_text_display}>"
 msgstr ""
-"{user} hat die Bewertung von {review.author} für <{link}|"
-"{source.title_text_display}> gelöscht"
+"{user} hat {review.author} Review für <{link}|{source.title_text_display}"
+"gelöscht>"
 
 #: hypha/apply/activity/adapters/slack.py:79
 #, python-brace-format
@@ -417,8 +424,8 @@ msgid ""
 "{user} has deleted {review_opinion.author} review opinion for <{link}|"
 "{source.title_text_display}>"
 msgstr ""
-"{user} hat die Bewertung von {review_opinion.author} für <{link}|"
-"{source.title_text_display}> gelöscht"
+"{user} hat die {review_opinion.author}-Bewertung für <{link}|"
+"{source.title_text_display}gelöscht>"
 
 #: hypha/apply/activity/adapters/slack.py:82
 #, python-brace-format
@@ -431,8 +438,8 @@ msgid ""
 "The lead of project <{link}|{source.title}> has been updated from {old_lead} "
 "to {source.lead} by {user}"
 msgstr ""
-"Der Lead des Projekts <{link}|{source.title}> wurde von {old_lead} zu "
-"{source.lead} durch {user} aktualisiert"
+"Der Lead des Projekts <{link}|{source.title}> wurde von {old_lead} auf "
+"{source.lead} von {user} aktualisiert"
 
 #: hypha/apply/activity/adapters/slack.py:88
 #, python-brace-format
@@ -440,7 +447,7 @@ msgid ""
 "The project title has been updated from <{link}|{old_title}> to <{link}|"
 "{source.title}> by {user}"
 msgstr ""
-"Der Projekttitle wurde von <{link}|{old_title}> zu <{link}|{source.title}> "
+"Der Projekttitel wurde von <{link}|{old_title}> auf <{link}|{source.title}> "
 "von {user} aktualisiert"
 
 #: hypha/apply/activity/adapters/slack.py:91
@@ -449,20 +456,19 @@ msgid ""
 "{user} has edited {review.author} review for <{link}|"
 "{source.title_text_display}>"
 msgstr ""
-"{user} hat die Bewertung von {review.author} für <{link}|"
-"{source.title_text_display}> bearbeitet"
+"{user} hat {review.author} review für <{link}|{source.title_text_display} "
+"bearbeitet>"
 
 #: hypha/apply/activity/adapters/slack.py:94
 #, python-brace-format
 msgid "{user} has requested approval on project <{link}|{source.title}>"
 msgstr ""
-"{user} hat eine Genehmigung für das Projekt <{link}|{source.title}> "
-"angefordert"
+"{user} hat die Genehmigung für Projekt <{link}|{source.title}> beantragt"
 
 #: hypha/apply/activity/adapters/slack.py:97
 #, python-brace-format
 msgid "{user} has approved project <{link}|{source.title}>"
-msgstr "{user} hat das Projekt <{link}|{source.title}> genehmigt"
+msgstr "{user} hat Projekt <{link}|{source.title} genehmigt>"
 
 #: hypha/apply/activity/adapters/slack.py:100
 #, python-brace-format
@@ -470,13 +476,12 @@ msgid ""
 "{user} has requested changes for project acceptance on <{link}|{source.title}"
 ">"
 msgstr ""
-"{user} hat Änderungen für die Projektzulassung von <{link}|{source.title}> "
-"angefordert"
+"{user} hat Änderungen für die Projektakzeptanz auf <{link}|{source.title}>"
 
 #: hypha/apply/activity/adapters/slack.py:103
 #, python-brace-format
 msgid "{user} has uploaded a contract for <{link}|{source.title}>"
-msgstr "{user} hat einen Vertrag für <{link}|{source.title}> hochgeladen"
+msgstr "{user} hat einen Vertrag für <{link}|{source.title}>"
 
 #: hypha/apply/activity/adapters/slack.py:106
 #, python-brace-format
@@ -484,18 +489,18 @@ msgid ""
 "{user} has submitted the contracting document for project <{link}|"
 "{source.title}>"
 msgstr ""
-"{user} hat das Vertragsdokument für das Projekt <{link}|{source.title}> "
-"eingereicht"
+"{user} hat das Vertragsdokument für Projekt <{link}|{source.title} "
+"eingereicht>"
 
 #: hypha/apply/activity/adapters/slack.py:109
 #, python-brace-format
 msgid "{user} has approved contract for <{link}|{source.title}>"
-msgstr "{user} hat den Vertrag für <{link}|{source.title}> genehmigt"
+msgstr "{user} hat den Vertrag für <{link}|{source.title} genehmigt>"
 
 #: hypha/apply/activity/adapters/slack.py:112
 #, python-brace-format
 msgid "{user} has created invoice for <{link}|{source.title}>"
-msgstr "{user} hat eine Rechnung für <{link}|{source.title}> erstellt"
+msgstr "{user} hat eine Rechnung für <{link}|{source.title}>"
 
 #: hypha/apply/activity/adapters/slack.py:115
 #, python-brace-format
@@ -503,13 +508,13 @@ msgid ""
 "{user} has changed the status of <{link_related}|invoice> on <{link}|"
 "{source.title}> to {invoice.status_display}"
 msgstr ""
-"{user} hat den Status von <{link_related}|Rechnung> auf <{link}|"
-"{source.title}> zu {invoice.status_display} geändert"
+"{user} hat den Status von <{link_related}|invoice> auf <{link}|{source.title}"
+"> auf {invoice.status_display} geändert"
 
 #: hypha/apply/activity/adapters/slack.py:118
 #, python-brace-format
 msgid "{user} has deleted invoice from <{link}|{source.title}>"
-msgstr "{user} hat Rechnung von <{link}|{source.title}> gelöscht"
+msgstr "{user} hat die Rechnung von <{link}|{source.title}> gelöscht"
 
 #: hypha/apply/activity/adapters/slack.py:121
 #, python-brace-format
@@ -519,12 +524,12 @@ msgstr "{user} hat die Rechnung für <{link}|{source.title}> aktualisiert"
 #: hypha/apply/activity/adapters/slack.py:124
 #, python-brace-format
 msgid "{user} has submitted a report for <{link}|{source.title}>"
-msgstr "{user} hat einen Bericht für <{link}|{source.title}> eingereicht"
+msgstr "{user} hat einen Bericht für <{link}|{source.title}> übertragen"
 
 #: hypha/apply/activity/adapters/slack.py:128
 #, python-brace-format
 msgid "{user} has created a new account for <{link}|{source}>"
-msgstr "{user} hat ein neues Konto für <{link}|{source}> erstellt"
+msgstr "{user} hat einen neuen Account für <{link}|{source}> angelegt"
 
 #: hypha/apply/activity/adapters/slack.py:131
 #, python-brace-format
@@ -532,31 +537,29 @@ msgid ""
 "{user} has edited account for <{link}|{source}> that now has following "
 "roles: {roles}"
 msgstr ""
-"{user} hat das Konto für <{link}|{source}> bearbeitet, das jetzt die "
-"folgenden Rollen hat: {roles}"
+"{user} hat einen Account für <{link}|{source}> bearbeitet, der nun die "
+"Rolle: {roles} hat."
 
 #: hypha/apply/activity/adapters/slack.py:135
 #, python-brace-format
 msgid "{user} has archived the submission: {source.title_text_display}"
-msgstr "{user} hat die Einreichung archiviert: {source.title_text_display}"
+msgstr "{user} hat diese Einreichung archiviert: {source.title_text_display}"
 
 #: hypha/apply/activity/adapters/slack.py:138
 #, python-brace-format
 msgid "{user} has unarchived the submission: {source.title_text_display}"
 msgstr ""
-"{user} hat die Einreichung wiederhergestellt: {source.title_text_display}"
+"{user} hat diese Einreichung entarchiviert: {source.title_text_display}"
 
 #: hypha/apply/activity/adapters/slack.py:234
 #, python-brace-format
 msgid "{user} has updated the reviewers on <{link}|{title}>"
-msgstr "{user} hat die Reviewer für <{link}|{title}> aktualisiert"
+msgstr "{user} hat die Reviewer auf <{link}|{title}> aktualisiert"
 
 #: hypha/apply/activity/adapters/slack.py:253
 #, python-brace-format
 msgid "{user} has batch changed lead to {new_lead} on: {submissions_text}"
-msgstr ""
-"{user} hat den Lead in einer Charge zu {new_lead} geändert bei: "
-"{submissions_text}"
+msgstr "{user} hat den Lead auf {new_lead} geändert: {submissions_text}"
 
 #: hypha/apply/activity/adapters/slack.py:265
 #, python-brace-format
@@ -568,13 +571,12 @@ msgstr "{user} als {name},"
 msgid ""
 "{user} has batch added {reviewers_text} as reviewers on: {submissions_text}"
 msgstr ""
-"{user} hat {reviewers_text} als Reviewer für folgende Einreichungen "
-"hinzugefügt: {submissions_text}"
+"{user} hat {reviewers_text} als Reviewer hinzugefügt auf: {submissions_text}"
 
 #: hypha/apply/activity/adapters/slack.py:291
 #, python-brace-format
 msgid "{user} has transitioned the following submissions: {submissions_links}"
-msgstr "{user} hat die folgenden Einreichungen übergeben: {submissions_links}"
+msgstr "{user} hat die folgenden Einreichungen übertragen: {submissions_links}"
 
 #: hypha/apply/activity/adapters/slack.py:301
 #, python-brace-format
@@ -582,8 +584,8 @@ msgid ""
 "A determination for <{link}|{submission_title}> was sent by email. Outcome: "
 "{determination_outcome}"
 msgstr ""
-"Eine Entscheidung für <{link}|{submission_title}> wurde per E-Mail gesendet. "
-"Ergebnis: {determination_outcome}"
+"Eine Entscheidung für <{link}|{submission_title}> wurde per E-Mail "
+"verschickt. Ergebnis: {determination_outcome}"
 
 #: hypha/apply/activity/adapters/slack.py:308
 #, python-brace-format
@@ -591,23 +593,23 @@ msgid ""
 "A determination for <{link}|{submission_title}> was saved without sending an "
 "email. Outcome: {determination_outcome}"
 msgstr ""
-"Eine Entscheidung für <{link}|{submission_title}> wurde gespeichert, ohne "
-"dass eine E-Mail gesendet wurde. Ergebnis: {determination_outcome}"
+"Eine Entscheidung für <{link}|{submission_title}> wurde ohne E-Mail "
+"gespeichert. Ergebnis: {determination_outcome}"
 
 #: hypha/apply/activity/adapters/slack.py:324
 #, python-brace-format
 msgid "Determinations of {outcome} was sent for: {submissions_links}"
-msgstr "Entscheidung des {outcome} wurden gesendet für: {submissions_links}"
+msgstr "Entscheidungen von {outcome} wurde geschickt für: {submissions_links}"
 
 #: hypha/apply/activity/adapters/slack.py:335
 #, python-brace-format
 msgid "{user} has deleted submissions: {title}"
-msgstr "{user} hat Einreichungen gelöscht: {title}"
+msgstr "{user} hat Einreichung gelöscht: {title}"
 
 #: hypha/apply/activity/adapters/slack.py:342
 #, python-brace-format
 msgid "{user} has archived submissions: {title}"
-msgstr "{user} hat Einreichungen archiviert: {title}"
+msgstr "{user} hat Einreichung archiviert: {title}"
 
 #: hypha/apply/activity/adapters/slack.py:356
 #, python-brace-format
@@ -615,8 +617,8 @@ msgid ""
 "<{link}|{title}> is ready for review. The following are assigned as "
 "reviewers: {reviewers}"
 msgstr ""
-"<{link}|{title}> ist für die Überprüfung bereit. Als Reviewer sind "
-"zugewiesen: {reviewers}"
+"<{link}|{title}> ist zur Überprüfung bereit. Folgende Reviewer sind "
+"zugeteilt: {reviewers}"
 
 #: hypha/apply/activity/adapters/utils.py:42
 #, python-brace-format
@@ -624,18 +626,16 @@ msgid " as {role}"
 msgstr " als {role}"
 
 #: hypha/apply/activity/filters.py:13
-#: hypha/apply/funds/templates/submissions/all.html:617
 msgid "Today"
 msgstr "Heute"
 
 #: hypha/apply/activity/filters.py:14
-#: hypha/apply/funds/templates/submissions/all.html:618
 msgid "Yesterday"
 msgstr "Gestern"
 
 #: hypha/apply/activity/filters.py:15
 msgid "Past 7 days"
-msgstr "Letzte 7 Tage"
+msgstr "Die letzten 7 Tage"
 
 #: hypha/apply/activity/filters.py:16
 msgid "This month"
@@ -643,15 +643,15 @@ msgstr "Diesen Monat"
 
 #: hypha/apply/activity/filters.py:17
 msgid "Last 3 months"
-msgstr "Letzte 3 Monate"
+msgstr "Die letzten 3 Monate"
 
 #: hypha/apply/activity/forms.py:16
-#: hypha/apply/projects/templates/application_projects/report_detail.html:42
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:70
 msgid "Attachments"
-msgstr "Anhänge"
+msgstr "Anlagen"
 
-#: hypha/apply/activity/forms.py:20 hypha/apply/funds/forms.py:100
-#: hypha/apply/funds/forms.py:240 hypha/apply/funds/forms.py:338
+#: hypha/apply/activity/forms.py:20 hypha/apply/funds/forms.py:103
+#: hypha/apply/funds/forms.py:243 hypha/apply/funds/forms.py:341
 msgid "Select..."
 msgstr "Auswählen..."
 
@@ -665,9 +665,11 @@ msgstr "Zusammenfassung aller Aktivitäten"
 
 #: hypha/apply/activity/management/commands/send_staff_email_digest.py:162
 msgid "Activities Summary - "
-msgstr "Aktivitätenzusammenfassung - "
+msgstr "Zusammenfassung der Aktivitäten – "
 
-#: hypha/apply/activity/models.py:25 hypha/apply/todo/options.py:59
+#: hypha/apply/activity/models.py:25
+#: hypha/apply/funds/models/co_applicants.py:9
+#: hypha/apply/projects/models/payment.py:117 hypha/apply/todo/options.py:63
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -677,7 +679,7 @@ msgstr "Aktion"
 
 #: hypha/apply/activity/models.py:32
 msgid "applicant"
-msgstr "Bewerber"
+msgstr "Antragsteller"
 
 #: hypha/apply/activity/models.py:33
 msgid "team"
@@ -697,31 +699,31 @@ msgstr "alle"
 
 #: hypha/apply/activity/models.py:41
 msgid "Applicants"
-msgstr "Bewerber"
+msgstr "Antragsteller"
 
 #: hypha/apply/activity/models.py:42
 msgid "Staff only"
-msgstr "Nur für Team"
+msgstr "Nur Personal"
 
-#: hypha/apply/activity/models.py:43 hypha/apply/funds/tables.py:347
-#: hypha/apply/funds/tables.py:592
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:68
+#: hypha/apply/activity/models.py:43 hypha/apply/funds/tables.py:278
+#: hypha/apply/funds/tables.py:508
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:81
 msgid "Reviewers"
-msgstr "Reviewer"
+msgstr "Reviewers"
 
-#: hypha/apply/activity/models.py:44 hypha/apply/funds/forms.py:334
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:74
+#: hypha/apply/activity/models.py:44 hypha/apply/funds/forms.py:337
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:87
 msgid "Partners"
 msgstr "Partner"
 
 #: hypha/apply/activity/models.py:45
-#: hypha/apply/funds/templates/funds/submissions_result.html:55
+#: hypha/apply/funds/templates/funds/submissions_result.html:77
 msgid "All"
 msgstr "Alle"
 
 #: hypha/apply/activity/models.py:46
 msgid "Applicants & Partners"
-msgstr "Bewerber & Partner"
+msgstr "Antragsteller & Partner"
 
 #: hypha/apply/activity/models.py:373
 msgid "verb"
@@ -733,23 +735,23 @@ msgstr "aktualisierter Lead"
 
 #: hypha/apply/activity/options.py:8
 msgid "batch updated lead"
-msgstr "batch updated lead"
+msgstr "Aktualisierter Batchlead"
 
 #: hypha/apply/activity/options.py:9
 msgid "edited submission"
-msgstr "bearbeitete Einreichung"
+msgstr "Bearbeitete Einreichung"
 
 #: hypha/apply/activity/options.py:10
 msgid "edited applicant"
-msgstr "bearbeiteter Bewerber"
+msgstr "Bearbeiteter Antragsteller"
 
 #: hypha/apply/activity/options.py:11
 msgid "submitted new submission"
-msgstr "neue Einreichung eingereicht"
+msgstr "übertragene neue Einreichung"
 
 #: hypha/apply/activity/options.py:12
 msgid "submitted new draft submission"
-msgstr "neuen Entwurf eingereicht"
+msgstr "übertragener neuer Entwurf"
 
 #: hypha/apply/activity/options.py:13
 msgid "screened"
@@ -757,51 +759,51 @@ msgstr "gesichtet"
 
 #: hypha/apply/activity/options.py:14
 msgid "transitioned"
-msgstr "übertragen"
+msgstr "umgestellt"
 
 #: hypha/apply/activity/options.py:15
 msgid "batch transitioned"
-msgstr "batch transitioned"
+msgstr "Batch-Übergang"
 
 #: hypha/apply/activity/options.py:16
 msgid "sent determination outcome"
-msgstr "Entscheidungsergebnis senden"
+msgstr "Entscheidungsergebnis gesendet"
 
 #: hypha/apply/activity/options.py:19
 msgid "sent batch determination outcome"
-msgstr "Sende Ergebnis der Chargenzuordnung"
+msgstr "Batch Entscheidung gesendet"
 
 #: hypha/apply/activity/options.py:21
 msgid "invited to proposal"
-msgstr "zur Konzept­einreichung eingeladen"
+msgstr "Eingeladen für Vorschlag"
 
 #: hypha/apply/activity/options.py:22
 msgid "updated reviewers"
-msgstr "aktualisierte Reviewer"
+msgstr "Aktualisierte Reviewer"
 
 #: hypha/apply/activity/options.py:23
 msgid "batch updated reviewers"
-msgstr "batch updated reviewers"
+msgstr "aktualisierte Batch Reviewer"
 
 #: hypha/apply/activity/options.py:24
 msgid "updated partners"
-msgstr "aktualisierte Partner"
+msgstr "Aktualisierte Partner"
 
 #: hypha/apply/activity/options.py:25
 msgid "partners updated partner"
-msgstr "Partner aktualisierten Partner"
+msgstr "durch Partner aktualisierte Partner"
 
 #: hypha/apply/activity/options.py:26
 msgid "marked ready for review"
-msgstr "als zur Bewertung bereit markiert"
+msgstr "als bereit zur Überprüfung markiert"
 
 #: hypha/apply/activity/options.py:29
 msgid "marked batch ready for review"
-msgstr "markierte Charge als zur Bewertung bereit"
+msgstr "markiertes Batch bereit zum Review"
 
 #: hypha/apply/activity/options.py:31
 msgid "added new review"
-msgstr "neue Bewertung hinzugefügt"
+msgstr "Neues Review hinzugeffügt"
 
 #: hypha/apply/activity/options.py:32
 msgid "added comment"
@@ -809,27 +811,27 @@ msgstr "Kommentar hinzugefügt"
 
 #: hypha/apply/activity/options.py:33
 msgid "submitted proposal"
-msgstr "eingereichtes Konzept"
+msgstr "eingereichter Vorschlag"
 
 #: hypha/apply/activity/options.py:34
 msgid "opened sealed submission"
-msgstr "gesperrte Einreichung geöffnet"
+msgstr "versiegelte Einreichung geöffnet"
 
 #: hypha/apply/activity/options.py:35
 msgid "reviewed opinion"
-msgstr "geprüfte Meinung"
+msgstr "Geprüfte Meinung"
 
 #: hypha/apply/activity/options.py:36
 msgid "deleted submission"
-msgstr "gelöschte Einreichung"
+msgstr "Gelöschte Einreichung"
 
 #: hypha/apply/activity/options.py:37
 msgid "deleted review"
-msgstr "gelöschte Bewertung"
+msgstr "Gelöschtes Review"
 
 #: hypha/apply/activity/options.py:38
 msgid "deleted review opinion"
-msgstr "gelöschte Stellungnahme zur Bewertung"
+msgstr "gelöschte Review-Meinung"
 
 #: hypha/apply/activity/options.py:39
 msgid "created project"
@@ -837,27 +839,27 @@ msgstr "erstelltes Projekt"
 
 #: hypha/apply/activity/options.py:40
 msgid "updated project lead"
-msgstr "aktualisiertes Projektverantwortlicher"
+msgstr "Aktualisierter Projektleiter"
 
 #: hypha/apply/activity/options.py:41
 msgid "updated project title"
-msgstr "aktualisierter Projekttitle"
+msgstr "Aktualisierter Projekttitel"
 
 #: hypha/apply/activity/options.py:42
 msgid "edited review"
-msgstr "bearbeitete Bewertung"
+msgstr "Bearbeitetes Review"
 
 #: hypha/apply/activity/options.py:43
 msgid "sent for approval"
-msgstr "zur Genehmigung gesendet"
+msgstr "zur Genehmigung geschickt"
 
 #: hypha/apply/activity/options.py:44
 msgid "approved project"
-msgstr "Genehmigtes Projekt"
+msgstr "Projektformular Prüfer zuweisen"
 
 #: hypha/apply/activity/options.py:45
 msgid "assign project form approver"
-msgstr "Projektformular Genehmiger zuweisen"
+msgstr "Projektformular-Prüfer zuweisen"
 
 #: hypha/apply/activity/options.py:46
 msgid "approved project form"
@@ -865,23 +867,23 @@ msgstr "Genehmigtes Projektformular"
 
 #: hypha/apply/activity/options.py:47
 msgid "transitioned project"
-msgstr "übertragenes Projekt"
+msgstr "Übertragenes Projekt"
 
 #: hypha/apply/activity/options.py:48
 msgid "requested project change"
-msgstr "Anfrage zur Änderung des Projekts"
+msgstr "Angeforderte Projektänderung"
 
 #: hypha/apply/activity/options.py:51
 msgid "submitted contract documents"
-msgstr "eingereichte Vertragsdokumente"
+msgstr "eingereichte Vertragsunterlagen"
 
 #: hypha/apply/activity/options.py:53
 msgid "uploaded document to project"
-msgstr "hochgeladenes Dokument zum Projekt"
+msgstr "Dokument zum Projekt hochgeladen"
 
 #: hypha/apply/activity/options.py:54
 msgid "uploaded contract to project"
-msgstr "hochgeladenen Vertrag zum Projekt"
+msgstr "Hochgeladener Vertrag an das Projekt"
 
 #: hypha/apply/activity/options.py:55
 msgid "approved contract"
@@ -889,11 +891,11 @@ msgstr "Genehmigter Vertrag"
 
 #: hypha/apply/activity/options.py:56
 msgid "created invoice for project"
-msgstr "Rechnung für Projekt erstellt"
+msgstr "erstellte Rechnung für das Projekt"
 
 #: hypha/apply/activity/options.py:57
 msgid "updated invoice status"
-msgstr "aktualisierter Rechnungsstatus"
+msgstr "Aktualisierter Rechnungsstatus"
 
 #: hypha/apply/activity/options.py:58
 msgid "approve invoice"
@@ -901,15 +903,15 @@ msgstr "Rechnung genehmigen"
 
 #: hypha/apply/activity/options.py:59
 msgid "deleted invoice"
-msgstr "gelöschte Rechnung"
+msgstr "Rechnung gelöscht"
 
 #: hypha/apply/activity/options.py:60
 msgid "sent project to compliance"
-msgstr "Projekt an Compliance gesendet"
+msgstr "Projekt zur Compliance geschickt"
 
 #: hypha/apply/activity/options.py:61
 msgid "updated invoice"
-msgstr "aktualisierte Rechnung"
+msgstr "Aktualisierte Rechnung"
 
 #: hypha/apply/activity/options.py:62
 msgid "submitted report"
@@ -917,35 +919,35 @@ msgstr "eingereichter Bericht"
 
 #: hypha/apply/activity/options.py:63
 msgid "skipped report"
-msgstr "übersprungenen Bericht"
+msgstr "Bericht übersprungen"
 
 #: hypha/apply/activity/options.py:64
 msgid "changed report frequency"
-msgstr "Änderung der Berichtshäufigkeit"
+msgstr "geänderter Berichtszyklus"
 
 #: hypha/apply/activity/options.py:66
 msgid "notified report"
-msgstr "gemeldeter Bericht"
+msgstr "Mitgeteilter Bericht"
 
 #: hypha/apply/activity/options.py:67
 msgid "reminder to review"
-msgstr "Erinnerung zur Bewertung"
+msgstr "Erinnerung zur Überprüfung"
 
 #: hypha/apply/activity/options.py:68
 msgid "batch deleted submissions"
-msgstr "batch deleted submissions"
+msgstr "Batch-gelöschte Einreichungen"
 
 #: hypha/apply/activity/options.py:71
 msgid "batch archive submissions"
-msgstr "batch archive submissions"
+msgstr "Batch-Archiv-Einreichungen"
 
 #: hypha/apply/activity/options.py:75
 msgid "batch update invoice status"
-msgstr "batch update invoice status"
+msgstr "Batch-Update Rechnungsstatus"
 
 #: hypha/apply/activity/options.py:77
 msgid "created new account"
-msgstr "neu erstelltes Konto"
+msgstr "Neues Konto erstellt"
 
 #: hypha/apply/activity/options.py:78
 msgid "edited account"
@@ -953,19 +955,23 @@ msgstr "bearbeitetes Konto"
 
 #: hypha/apply/activity/options.py:79
 msgid "archived submission"
-msgstr "archivierte Einreichung"
+msgstr "Archivierte Einreichung"
 
 #: hypha/apply/activity/options.py:80
 msgid "unarchived submission"
-msgstr "nicht archivierte Einreichung"
+msgstr "Unarchivierte Einreichung"
 
 #: hypha/apply/activity/options.py:81
 msgid "remove task"
-msgstr "Aufgabe löschen"
+msgstr "Aufgabe entfernen"
+
+#: hypha/apply/activity/options.py:82
+msgid "invite co-applicant"
+msgstr "Mitantragsteller einladen"
 
 #: hypha/apply/activity/templates/activity/include/action_list.html:6
 msgid "There are no actions."
-msgstr "Es gibt keine Aktionen."
+msgstr "Keine Aufgaben."
 
 #: hypha/apply/activity/templates/activity/include/activity_list.html:29
 msgid "No comments available"
@@ -974,88 +980,88 @@ msgstr "Keine Kommentare verfügbar"
 #: hypha/apply/activity/templates/activity/notifications.html:3
 #: hypha/apply/activity/templates/activity/notifications.html:8
 msgid "Notifications"
-msgstr "Benachrichtigungen"
+msgstr "Anmerkungen"
 
-#: hypha/apply/activity/templates/activity/notifications.html:11
+#: hypha/apply/activity/templates/activity/notifications.html:9
 msgid "Activity feed across all applications and projects"
-msgstr "Aktivitätsfeed über alle Anträge und Projekte"
+msgstr "Aktivitätsfeed über alle Anwendungen und Projekte hinweg"
 
-#: hypha/apply/activity/templates/activity/notifications.html:13
+#: hypha/apply/activity/templates/activity/notifications.html:9
 msgid "Activity feed across all the applications"
-msgstr "Aktivitätsfeed über alle Anträge"
+msgstr "Aktivitätsfeed über alle Anwendungen hinweg"
 
-#: hypha/apply/activity/templates/activity/notifications.html:23
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:107
+#: hypha/apply/activity/templates/activity/notifications.html:17
 #: hypha/core/templates/components/dropdown-menu.html:64
 msgid "Filter"
-msgstr "Filtern"
+msgstr "Filter"
 
-#: hypha/apply/activity/templates/activity/notifications.html:82
+#: hypha/apply/activity/templates/activity/notifications.html:79
 #: hypha/apply/activity/templates/activity/ui/activity-action-item.html:44
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:31
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:39
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:46
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:26
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:67
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:102
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:135
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:76
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:62
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:13
-#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:65
-#: hypha/apply/todo/templates/todo/todolist_item.html:28
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:46
+#: hypha/apply/funds/models/co_applicants.py:8
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:62
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:76
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:99
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:133
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:159
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:72
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:19
+#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:67
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:83
 msgid "View"
-msgstr "Anzeigen"
+msgstr "Ansicht"
 
-#: hypha/apply/activity/templates/activity/notifications.html:96
+#: hypha/apply/activity/templates/activity/notifications.html:93
 msgid "No activities found, try updating your filters."
-msgstr ""
-"Keine Aktivitäten gefunden. Bitte versuchen Sie, Ihre Filter zu "
-"aktualisieren."
+msgstr "Keine Aktivitäten gefunden, versuche, deine Filter zu aktualisieren."
+
+#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:53
+msgid "Assigned to you"
+msgstr "Dir zugeteilt"
 
 #: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:55
-msgid "Assigned to you"
-msgstr "Ihnen Zugewiesen"
-
-#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:57
 #, python-format
 msgid "Assigned to %(assigned_to)s"
 msgstr "Zugewiesen an %(assigned_to)s"
 
-#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:80
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:70
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:28
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:46
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:68
-#: hypha/apply/determinations/templates/determinations/determination_detail.html:26
-#: hypha/apply/funds/templates/funds/admin/widgets/read_only.html:2
-#: hypha/apply/funds/templates/funds/application_preview.html:47
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:118
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:40
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:93
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:126
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:84
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:4
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:23
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:99
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:47
-#: hypha/apply/projects/templates/application_projects/report_detail.html:62
-#: hypha/apply/review/templates/review/review_detail.html:60
+#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:78
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:87
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:40
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:50
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:77
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:36
+#: hypha/apply/funds/models/co_applicants.py:10
+#: hypha/apply/funds/templates/funds/admin/widgets/read_only.html:10
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:112
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:53
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:90
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:98
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:122
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:170
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:5
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:29
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:145
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:44
+#: hypha/apply/review/templates/review/review_detail.html:82
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:88
+#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:86
 msgid "updated"
 msgstr "aktualisiert"
 
-#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:100
+#: hypha/apply/activity/templates/activity/ui/activity-comment-item.html:98
 msgid "View "
-msgstr "Anzeigen "
+msgstr "Ansicht "
 
-#: hypha/apply/activity/templates/activity/ui/edit_comment_form.html:25
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:59
-#: hypha/apply/funds/views/submission_edit.py:132
-#: hypha/apply/funds/views/submission_edit.py:317
+#: hypha/apply/activity/templates/activity/ui/edit_comment_form.html:27
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:78
+#: hypha/apply/funds/views/submission_edit.py:125
+#: hypha/apply/funds/views/submission_edit.py:304
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:19
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:47
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:119
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:148
 #: hypha/apply/funds/workflows/definitions/double_stage.py:20
 #: hypha/apply/funds/workflows/definitions/double_stage.py:48
 #: hypha/apply/funds/workflows/definitions/double_stage.py:98
@@ -1077,258 +1083,214 @@ msgstr "Anzeigen "
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:20
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:47
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:92
-#: hypha/apply/projects/templates/application_projects/report_form.html:57
-#: hypha/apply/projects/views/project.py:307
-#: hypha/apply/projects/views/project.py:343
-#: hypha/apply/projects/views/project.py:650
-#: hypha/apply/projects/views/project.py:769
-#: hypha/apply/projects/views/project.py:857
-#: hypha/apply/projects/views/project.py:896
-#: hypha/apply/projects/views/project.py:927
-#: hypha/apply/projects/views/project.py:960
-#: hypha/apply/projects/views/project.py:1312
-#: hypha/apply/projects/views/project.py:1385
-#: hypha/apply/projects/views/project.py:1416
-#: hypha/apply/projects/views/project.py:1571
-#: hypha/apply/review/templates/review/review_edit_form.html:64
-#: hypha/apply/review/templates/review/review_form.html:75
+#: hypha/apply/projects/reports/templates/reports/report_form.html:60
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:30
+#: hypha/apply/projects/views/project.py:309
+#: hypha/apply/projects/views/project.py:345
+#: hypha/apply/projects/views/project.py:692
+#: hypha/apply/projects/views/project.py:815
+#: hypha/apply/projects/views/project.py:903
+#: hypha/apply/projects/views/project.py:942
+#: hypha/apply/projects/views/project.py:976
+#: hypha/apply/projects/views/project.py:1009
+#: hypha/apply/projects/views/project.py:1363
+#: hypha/apply/projects/views/project.py:1436
+#: hypha/apply/projects/views/project.py:1467
+#: hypha/apply/projects/views/project.py:1622
+#: hypha/apply/review/templates/review/review_edit_form.html:67
+#: hypha/apply/review/templates/review/review_form.html:84
 #: hypha/apply/users/templates/two_factor/_wizard_actions.html:4
-#: hypha/apply/users/templates/users/change_password.html:46
+#: hypha/apply/users/templates/users/change_password.html:45
 msgid "Submit"
 msgstr "Senden"
 
-#: hypha/apply/activity/templates/activity/ui/edit_comment_form.html:26
-#: hypha/apply/funds/templates/funds/applicationsubmission_confirm_delete.html:47
+#: hypha/apply/activity/templates/activity/ui/edit_comment_form.html:28
 #: hypha/apply/funds/templates/funds/includes/delegated_form_base.html:30
 #: hypha/apply/funds/templates/funds/includes/modal_archive_submission_confirm.html:32
 #: hypha/apply/funds/templates/funds/includes/modal_unarchive_submission_confirm.html:34
-#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:56
+#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:58
 #: hypha/apply/funds/templates/funds/includes/update_reviewer_form.html:59
-#: hypha/apply/projects/templates/application_projects/project_form.html:28
+#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:40
+#: hypha/apply/projects/templates/application_projects/project_form.html:33
 #: hypha/apply/users/templates/users/become.html:33
+#: hypha/templates/cotton/modal/confirm.html:47
 #: hypha/templates/includes/dialog_form_base.html:39
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: hypha/apply/activity/templates/messages/email/activity_summary.md:4
-msgid "Activities Summary"
-msgstr "Aktivitätenzusammenfassung"
-
-#: hypha/apply/activity/templates/messages/email/activity_summary.md:7
-#, python-format
-msgid ""
-"\n"
-"There is %(total_count_apnumber)s new activity:\n"
-msgid_plural ""
-"\n"
-"There are %(total_count_apnumber)s new activities:\n"
-msgstr[0] ""
-"\n"
-"Es gibt %(total_count_apnumber)s Treffer\n"
-msgstr[1] ""
-"\n"
-"Es gibt %(total_count_apnumber)s Treffer\n"
-
-#: hypha/apply/activity/templates/messages/email/activity_summary.md:13
-#: hypha/apply/funds/templates/funds/submissions_result.html:33
-#: hypha/apply/funds/templates/submissions/all.html:7
-#: hypha/core/navigation.py:38 hypha/core/navigation.py:114
-msgid "Submissions"
-msgstr "Einreichungen"
-
-#: hypha/apply/activity/templates/messages/email/activity_summary.md:17
-#: hypha/apply/funds/tables.py:92
-msgid "Comments"
-msgstr "Kommentare"
-
-#: hypha/apply/activity/templates/messages/email/activity_summary.md:21
-#: hypha/apply/funds/templates/funds/reviewer_leaderboard.html:5
-#: hypha/apply/funds/templates/funds/reviewer_leaderboard_detail.html:5
-#: hypha/apply/funds/templates/funds/submissions_result.html:51
-#: hypha/apply/projects/templates/application_projects/paf_export.html:31
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:56
-#: hypha/apply/review/templates/review/review_list.html:4
-#: hypha/apply/review/templates/review/review_list.html:10
-#: hypha/core/navigation.py:59
-msgid "Reviews"
-msgstr "Bewertungen"
-
-#: hypha/apply/activity/templates/messages/email/activity_summary.md:25
-msgid "Other activities"
-msgstr ""
-
 #: hypha/apply/activity/templates/messages/email/applicant_base.html:4
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:7
+#: hypha/apply/activity/templates/messages/email/invite_co_applicant.html:4
 #, python-format
 msgid "Dear %(name)s,"
-msgstr "Sehr geehrte(r) %(name)s,"
+msgstr "Liebe(r) %(name)s,"
 
 #: hypha/apply/activity/templates/messages/email/applicant_base.html:7
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:28
-msgid "Link to your application"
-msgstr "Link zu Ihrer Bewerbung"
+msgid "View your project here"
+msgstr "Sieh dir hier deine Projekte an"
 
-#: hypha/apply/activity/templates/messages/email/applicant_base.html:9
-#: hypha/apply/activity/templates/messages/email/contract_uploaded.html:29
-#: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:11
-#: hypha/apply/activity/templates/messages/email/ready_for_invoicing.html:11
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:10
-msgid "If you have any questions, please submit them here"
-msgstr "Wenn Sie Fragen haben, senden Sie diese bitte hier ein"
+#: hypha/apply/activity/templates/messages/email/applicant_base.html:7
+msgid "View your submission here"
+msgstr "Sieh dir hier deine Einreichungen an"
 
-#: hypha/apply/activity/templates/messages/email/applicant_base.html:11
-#: hypha/apply/activity/templates/messages/email/contract_uploaded.html:31
-#: hypha/apply/activity/templates/messages/email/ready_for_invoicing.html:13
-msgid "See our guide for more information"
-msgstr "Siehe unsere Anleitung für weitere Informationen"
-
-#: hypha/apply/activity/templates/messages/email/applicant_base.html:13
-#: hypha/apply/activity/templates/messages/email/comment.html:16
-#: hypha/apply/activity/templates/messages/email/contract_uploaded.html:33
+#: hypha/apply/activity/templates/messages/email/applicant_base.html:10
+#: hypha/apply/activity/templates/messages/email/contract_uploaded.html:30
 #: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:15
+#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:11
+msgid "If you have any questions, please submit them here"
+msgstr "Wenn du Fragen hast, bitte stelle diese hier"
+
+#: hypha/apply/activity/templates/messages/email/applicant_base.html:12
+#: hypha/apply/activity/templates/messages/email/contract_uploaded.html:32
+msgid "See our guide for more information"
+msgstr "Schau in unsere Beschreibung für mehr Informationen"
+
+#: hypha/apply/activity/templates/messages/email/applicant_base.html:15
+#: hypha/apply/activity/templates/messages/email/comment.html:16
+#: hypha/apply/activity/templates/messages/email/contract_uploaded.html:35
+#: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:20
 #, python-format
 msgid ""
 "If you have any issues accessing the submission system or other general "
 "inquiries, please email us at %(ORG_EMAIL)s"
 msgstr ""
-"Wenn Sie Probleme beim Zugriff auf das Einreichungssystem oder andere "
-"allgemeine Anfragen haben, senden Sie uns bitte eine E-Mail an %(ORG_EMAIL)s"
+"Wenn du Probleme beim Zugriff auf das System hast oder allgemeine Fragen, "
+"schreib uns eine E-Mail an %(ORG_EMAIL)s"
 
 #: hypha/apply/activity/templates/messages/email/assign_paf_approvers.html:7
 msgid "Project documents are ready to be assigned for approval."
-msgstr ""
-"Projektunterlagen sind bereit, um für eine Genehmigung zugewiesen zu werden."
+msgstr "Projektdokumente sind bereit, zur Genehmigung zugewiesen zu werden."
 
 #: hypha/apply/activity/templates/messages/email/assign_paf_approvers.html:9
-#: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:10
+#: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:9
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:15
-#: hypha/apply/activity/templates/messages/email/invoice_approved.html:9
-#: hypha/apply/activity/templates/messages/email/invoice_status_updated.html:18
-#: hypha/apply/activity/templates/messages/email/invoice_updated.html:10
-#: hypha/apply/activity/templates/messages/email/paf_for_approval.html:9
-#: hypha/apply/activity/templates/messages/email/partners_update_applicant.html:10
-#: hypha/apply/activity/templates/messages/email/partners_update_partner.html:10
-#: hypha/apply/activity/templates/messages/email/project_final_approval.html:9
-#: hypha/apply/activity/templates/messages/email/project_request_change.html:9
-#: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:9
+#: hypha/apply/activity/templates/messages/email/partners_update_applicant.html:9
+#: hypha/apply/activity/templates/messages/email/partners_update_partner.html:9
 #: hypha/apply/activity/templates/messages/email/ready_to_review.html:8
-#: hypha/apply/activity/templates/messages/email/report_frequency.html:12
-#: hypha/apply/activity/templates/messages/email/report_skipped.html:12
-#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:9
-#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:11
-#: hypha/apply/funds/templates/funds/revisions_compare.html:34
+#: hypha/apply/funds/templates/funds/revisions_compare.html:42
+#: hypha/apply/funds/templates/funds/revisions_compare.html:43
 #: hypha/core/models/system_settings.py:21
 msgid "Title"
 msgstr "Titel"
 
 #: hypha/apply/activity/templates/messages/email/assign_paf_approvers.html:10
-#: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:11
+#: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:10
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:16
-#: hypha/apply/activity/templates/messages/email/invoice_approved.html:10
-#: hypha/apply/activity/templates/messages/email/invoice_updated.html:11
-#: hypha/apply/activity/templates/messages/email/paf_for_approval.html:10
-#: hypha/apply/activity/templates/messages/email/partners_update_applicant.html:11
-#: hypha/apply/activity/templates/messages/email/partners_update_partner.html:11
-#: hypha/apply/activity/templates/messages/email/project_created.html:11
-#: hypha/apply/activity/templates/messages/email/project_final_approval.html:10
-#: hypha/apply/activity/templates/messages/email/project_request_change.html:10
-#: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:10
+#: hypha/apply/activity/templates/messages/email/invite_co_applicant.html:13
+#: hypha/apply/activity/templates/messages/email/partners_update_applicant.html:10
+#: hypha/apply/activity/templates/messages/email/partners_update_partner.html:10
 #: hypha/apply/activity/templates/messages/email/ready_to_review.html:11
-#: hypha/apply/activity/templates/messages/email/report_frequency.html:13
-#: hypha/apply/activity/templates/messages/email/report_skipped.html:13
-#: hypha/apply/activity/templates/messages/email/report_submitted.html:11
-#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:10
-#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:12
 msgid "Link"
 msgstr "Link"
 
 #: hypha/apply/activity/templates/messages/email/assign_paf_approvers.html:12
-#: hypha/apply/activity/templates/messages/email/invoice_approved.html:13
-#: hypha/apply/activity/templates/messages/email/paf_for_approval.html:12
-#: hypha/apply/activity/templates/messages/email/project_final_approval.html:12
-#: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:13
-#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:12
-#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:14
+#: hypha/apply/activity/templates/messages/email/invoice_approved.html:10
+#: hypha/apply/activity/templates/messages/email/paf_for_approval.html:11
+#: hypha/apply/activity/templates/messages/email/project_final_approval.html:11
+#: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:11
+#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:11
+#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:12
 #, python-format
 msgid "Please contact %(lead)s - %(email)s if you have any questions."
-msgstr "Bitte kontaktieren Sie %(lead)s - %(email)s, wenn Sie Fragen haben."
+msgstr "Bitte kontaktiere  %(lead)s - %(email)s wenn du Fragen hast."
 
 #: hypha/apply/activity/templates/messages/email/base.html:2
 #: hypha/apply/users/templates/users/activation/email.txt:2
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:2
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:2
-#: hypha/apply/users/templates/users/emails/confirm_access.md:2
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:2
 #: hypha/apply/users/templates/users/emails/set_password.txt:2
 #: hypha/apply/users/templates/users/password_reset/email.txt:2
 #, python-format
 msgid "Dear %(user)s,"
-msgstr "Sehr geehrter %(user)s,"
+msgstr "Liebe(r) %(user)s,"
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
+#: hypha/apply/users/templates/users/activation/email.txt:17
+#: hypha/apply/users/templates/users/email_change/confirm_email.txt:10
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
+#: hypha/apply/users/templates/users/emails/set_password.txt:10
+#: hypha/apply/users/templates/users/password_reset/email.txt:10
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
-msgstr "Mit freundlichen Grüßen,     Das %(ORG_SHORT_NAME)s-Team"
+"The %(org_short_name)s Team"
+msgstr ""
+"Schöne Grüße,\n"
+"Das %(org_short_name)s Team"
 
 #: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:4
 #: hypha/apply/activity/templates/messages/email/ready_to_review.html:4
 msgid "Dear Reviewer,"
-msgstr "Sehr geehrter Reviewer,"
+msgstr "Liebe(r) Reviewer,"
 
 #: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:7
 msgid "New applications have been added to your review list."
-msgstr "Es wurden neue Anträge zu Ihrer Bewertungsliste hinzugefügt."
-
-#: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:9
-#: hypha/apply/activity/templates/messages/email/partners_update_applicant.html:9
-#: hypha/apply/activity/templates/messages/email/partners_update_partner.html:9
-msgid "ID"
-msgstr "ID"
+msgstr "Neue Einreichungen wurden zu deiner Review-Liste hinzugefügt."
 
 #: hypha/apply/activity/templates/messages/email/comment.html:4
 #: hypha/apply/activity/templates/messages/email/partners_update_partner.html:4
 msgid "Dear"
-msgstr "Sehr geehrte(r)"
+msgstr "Liebe(r)"
 
 #: hypha/apply/activity/templates/messages/email/comment.html:10
 #, python-format
 msgid "There has been a new comment on \"%(title)s\" by %(display_user)s."
-msgstr "Es gibt einen neuen Kommentar zu \"%(title)s\" von %(display_user)s."
+msgstr "Es gibt einen neuen Kommentar bei \"%(title)s\" von %(display_user)s."
 
 #: hypha/apply/activity/templates/messages/email/comment.html:12
 msgid "Read the full comment here"
-msgstr "Lesen Sie den vollständigen Kommentar hier"
+msgstr "Lies hier den vollständigen Kommentar"
 
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:13
 msgid "A new contract has been added to your Project"
-msgstr "Ein neuer Vertrag wurde Ihrem Projekt hinzugefügt"
+msgstr "Ein neuer Vertrag wurde zu deinem Projekt hinzugefügt"
 
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:19
 msgid ""
 "This contract has already been signed and there is no action for you to take."
 msgstr ""
-"Dieser Vertrag wurde bereits unterzeichnet und es gibt keine Aktionen, die "
-"Sie ausführen müssen."
+"Dieser Vertrag wurde bereits unterzeichnet. Es ist keine Aufgabe weiter "
+"vorhanden."
 
 #: hypha/apply/activity/templates/messages/email/contract_uploaded.html:21
 #, python-format
 msgid ""
-"Please review the contract and sign it before reuploading it to your Project "
-"page for the %(ORG_SHORT_NAME)s Team to approve."
+"Please review the contract and sign it before reuploading it to your project "
+"page for the %(ORG_SHORT_NAME)s team to approve."
 msgstr ""
-"Bitte überprüfen Sie den Vertrag und unterzeichnen Sie ihn, bevor Sie ihn "
-"erneut auf Ihrer Projektseite hochladen, damit das %(ORG_SHORT_NAME)s-Team "
-"ihn genehmigen kann."
+"Bitte überprüfen Sie den Vertrag und unterschreiben Sie ihn, bevor Sie ihn "
+"erneut auf Ihre Projektseite hochladen, damit das Team von "
+"%(ORG_SHORT_NAME)s ihn genehmigen kann."
 
 #: hypha/apply/activity/templates/messages/email/determination.html:5
 msgid "Your application has been reviewed and the outcome is"
-msgstr "Ihr Konzept wurde überprüft und das Ergebnis ist"
+msgstr "Deine Einreichung wurde gereviewt. Das Ergebnis ist"
 
 #: hypha/apply/activity/templates/messages/email/determination.html:9
 msgid "Read the full determination here"
-msgstr "Weitere Informationen finden Sie hier"
+msgstr "Lies das vollständige Ergebnis hier"
+
+#: hypha/apply/activity/templates/messages/email/invite_co_applicant.html:7
+#, python-format
+msgid ""
+"You have been invited as a co-applicant to an application on "
+"%(ORG_SHORT_NAME)s by %(user)s."
+msgstr ""
+"Sie wurden von %(user)s als Mitantragsteller zu einem Antrag auf "
+"%(ORG_SHORT_NAME)s eingeladen."
+
+#: hypha/apply/activity/templates/messages/email/invite_co_applicant.html:9
+msgid ""
+"But You can't accept this invite because you already hold a responsible "
+"position in"
+msgstr ""
+"Sie können diese Einladung jedoch nicht annehmen, da Sie bereits eine "
+"verantwortungsvolle Position in"
+
+#: hypha/apply/activity/templates/messages/email/invite_co_applicant.html:11
+msgid "Click on link if you want to accept it."
+msgstr "Klicken Sie auf den Link, wenn Sie ihn akzeptieren möchten."
 
 #: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:5
 #, python-format
@@ -1338,86 +1300,120 @@ msgid ""
 "with more details about your project. You will receive a second email "
 "linking to a determination message with detailed feedback."
 msgstr ""
-"Wir haben Ihre Projektskizze überprüft und denken, dass sie für eine "
-"%(ORG_SHORT_NAME)s-Finanzierung geeignet sein könnte. Wir möchten Sie "
-"einladen, ein Konzept mit weiteren Details zu Ihrem Projekt einzureichen."
+"Wir haben Ihre Konzeptnotiz geprüft und denken, dass sie gut für "
+"%(ORG_SHORT_NAME)s Finanzierung geeignet sein könnte. Wir möchten Sie "
+"einladen, einen Vorschlag mit weiteren Details zu Ihrem Projekt "
+"einzureichen. Sie erhalten eine zweite E-Mail mit einem Link zu einer "
+"Entscheidung und detailliertem Feedback."
 
-#: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:7
+#: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:8
 #, python-format
 msgid ""
 "Please review our Proposal Guide at %(ORG_GUIDE_URL)s to learn more about "
 "the information we’d like to see. In the proposal please also address the "
 "feedback we provided in the concept note determination."
 msgstr ""
-"Bitte überprüfen Sie unseren Konzeptleitfaden unter %(ORG_GUIDE_URL)s, um "
-"mehr über die Informationen zu erfahren, die wir gerne sehen würden. Bitte "
-"gehen Sie in Ihrem Konzept auch auf die Rückmeldungen ein, die wir in der "
-"Entscheidung zur Notiz zur Projekskizze bereitgestellt haben."
-
-#: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:10
-msgid "Here is the link to start creating your proposal"
-msgstr "Hier ist der Link, um mit der Erstellung Ihres Konzeptes zu beginnen"
+"Bitte lesen Sie unseren Vorschlagsleitfaden unter %(ORG_GUIDE_URL)s, um mehr "
+"über die Informationen zu erfahren, die wir gerne sehen würden. Im Vorschlag "
+"sollten Sie auch auf das Feedback eingehen, das wir in der Konzeptnotiz-"
+"Bestimmung gegeben haben."
 
 #: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:13
+msgid "Here is the link to start creating your proposal"
+msgstr "Hier ist der Link, um mit der Erstellung Ihres Vorschlags zu beginnen"
+
+#: hypha/apply/activity/templates/messages/email/invited_to_proposal.html:18
 msgid ""
 "The system will allow you to save a draft of your proposal as you work on "
 "it. When you feel it is ready for our review, please click the “Submit” "
 "button and we’ll know to take a look at it. We’ll reply to you with feedback "
 "on your Proposal as quickly as possible."
 msgstr ""
-"Das System ermöglicht es Ihnen, einen Entwurf Ihres Konzeptes zu speichern, "
-"während Sie daran arbeiten. Wenn Sie das Gefühl haben, dass er bereit für "
-"unsere Überprüfung ist, klicken Sie bitte auf die Schaltfläche „Senden“. Wir "
-"erfahren dann, dass wir ihn uns ansehen müssen. Wir werden Ihnen so schnell "
-"wie möglich Feedback zu Ihrem Konzept geben."
+"Das System ermöglicht es Ihnen, einen Entwurf Ihres Vorschlags während der "
+"Arbeit zu speichern. Wenn Sie das Gefühl haben, dass es für unsere Bewertung "
+"bereit ist, klicken Sie bitte auf die Schaltfläche \"Absenden\" und wir "
+"wissen, dass wir es uns ansehen können. Wir antworten Ihnen so schnell wie "
+"möglich mit Feedback zu Ihrem Vorschlag."
 
-#: hypha/apply/activity/templates/messages/email/invoice_approved.html:7
-msgid "An Invoice is waiting for your approval."
-msgstr "Eine Rechnung wartet auf Ihre Genehmigung."
+#: hypha/apply/activity/templates/messages/email/invoice_approved.html:6
+#, python-format
+msgid "An invoice on project \"%(title)s\" is waiting for your approval."
+msgstr "Eine Rechnung zum Projekt „%(title)s“ wartet auf Ihre Genehmigung."
 
-#: hypha/apply/activity/templates/messages/email/invoice_approved.html:11
-#: hypha/apply/activity/templates/messages/email/project_created.html:10
-#: hypha/apply/activity/templates/messages/email/report_submitted.html:10
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:40
-#: hypha/apply/funds/templates/funds/comments.html:35
-#: hypha/apply/funds/templates/funds/includes/submission-list-row.html:128
-#: hypha/apply/funds/templates/funds/includes/submission-table-row.html:53
-#: hypha/apply/projects/templates/application_projects/project_detail.html:36
-msgid "Project"
-msgstr "Projekt"
+#: hypha/apply/activity/templates/messages/email/invoice_approved.html:8
+#: hypha/apply/activity/templates/messages/email/invoice_created.html:8
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_staff.html:15
+msgid "View the invoice here"
+msgstr "Die Rechnung hier anzeigen"
 
-#: hypha/apply/activity/templates/messages/email/invoice_status_updated.html:7
-#: hypha/apply/activity/templates/messages/email/invoice_updated.html:7
+#: hypha/apply/activity/templates/messages/email/invoice_created.html:6
+#, python-format
+msgid "A new invoice has been submitted for project \"%(title)s\"."
+msgstr "Für das Projekt „%(title)s“ wurde eine neue Rechnung eingereicht."
+
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_applicant.html:7
 #, python-format
 msgid ""
-"An %(ORG_SHORT_NAME)s staff member has updated your invoice for %(title)s "
-"for period %(date_from)s to %(date_to)s."
+"An %(ORG_SHORT_NAME)s staff member has updated the status for an invoice on "
+"your project \"%(title)s\"."
 msgstr ""
-"Ein Teammitglied von %(ORG_SHORT_NAME)s hat Ihre Rechnung für %(title)s für "
-"den Zeitraum %(date_from)s bis %(date_to)s aktualisiert."
+"Ein Mitarbeiter von %(ORG_SHORT_NAME)s hat den Status einer Rechnung für Ihr "
+"Projekt „%(title)s” aktualisiert."
 
-#: hypha/apply/activity/templates/messages/email/invoice_status_updated.html:9
-#: hypha/apply/activity/templates/messages/email/invoice_updated.html:8
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_applicant.html:9
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_staff.html:9
 #, python-format
-msgid "It is now %(invoice_status)s."
-msgstr "Es ist jetzt %(invoice_status)s."
+msgid "It's status is now \"%(status)s\"."
+msgstr "Sein Status lautet nun „%(status)s“."
 
-#: hypha/apply/activity/templates/messages/email/invoice_status_updated.html:12
-msgid "The staff member left this comment"
-msgstr "Das Teammitglied hat folgenden Kommentar hinterlassen"
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_applicant.html:12
+msgid "A staff member left a comment that can be read here"
+msgstr ""
+"Ein Mitarbeiter hat einen Kommentar hinterlassen, der hier gelesen werden "
+"kann"
 
-#: hypha/apply/activity/templates/messages/email/invoice_status_updated.html:17
-msgid "Invoice Link"
-msgstr "Rechnungslink"
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_applicant.html:15
+msgid "View your invoice here"
+msgstr "Sehen Sie sich hier Ihre Rechnung an"
 
-#: hypha/apply/activity/templates/messages/email/invoice_status_updated.html:19
-msgid "Project Link"
-msgstr "Projektlink"
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_staff.html:7
+#, python-format
+msgid ""
+"An invoice on the project \"%(title)s\" had it's status updated by "
+"%(source_user)s."
+msgstr ""
+"Der Status einer Rechnung zum Projekt „%(title)s“ wurde von %(source_user)s "
+"aktualisiert."
+
+#: hypha/apply/activity/templates/messages/email/invoice_status_updated_staff.html:12
+msgid "A comment was left that can be read here"
+msgstr "Es wurde ein Kommentar hinterlassen, der hier gelesen werden kann"
+
+#: hypha/apply/activity/templates/messages/email/invoice_updated.html:6
+#, python-format
+msgid ""
+"An %(ORG_SHORT_NAME)s staff member has updated an invoice on your project "
+"\"%(title)s\"."
+msgstr ""
+"Ein Mitarbeiter von %(ORG_SHORT_NAME)s hat eine Rechnung für Ihr Projekt "
+"„%(title)s” aktualisiert."
+
+#: hypha/apply/activity/templates/messages/email/invoice_updated.html:8
+msgid "View the invoice here:"
+msgstr "Die Rechnung finden Sie hier:"
 
 #: hypha/apply/activity/templates/messages/email/paf_for_approval.html:7
-#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:7
-msgid "A Project is awaiting your review."
-msgstr "Ein Projekt wartet auf Ihre Bewertung."
+#, python-format
+msgid "The %(title)s project is awaiting your review."
+msgstr "Das Projekt %(title)s wartet auf Ihre Überprüfung."
+
+#: hypha/apply/activity/templates/messages/email/paf_for_approval.html:9
+#: hypha/apply/activity/templates/messages/email/project_request_change.html:13
+#: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:9
+#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:9
+#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:10
+msgid "View the project here"
+msgstr "Das Projekt hier ansehen"
 
 #: hypha/apply/activity/templates/messages/email/partners_update_applicant.html:5
 msgid "New partner(s) has been added to your submission."
@@ -1429,43 +1425,40 @@ msgstr "Sie wurden als Partner für die folgende Einreichung hinzugefügt."
 
 #: hypha/apply/activity/templates/messages/email/project_created.html:6
 #, python-format
-msgid "A Project has been created for your submission on %(ORG_SHORT_NAME)s."
+msgid ""
+"A project, \"%(title)s\" has been created for your submission to the "
+"%(ORG_LONG_NAME)s."
 msgstr ""
-"Ein Projekt wurde für Ihre Einreichung auf %(ORG_SHORT_NAME)s erstellt."
-
-#: hypha/apply/activity/templates/messages/email/project_created.html:8
-msgid "No action needed for now, wait until contract is ready for you to sign."
-msgstr ""
-"Keine Maßnahmen erforderlich. Bitte warten Sie, bis der Vertrag für Ihre "
-"Unterschrift bereit ist."
-
-#: hypha/apply/activity/templates/messages/email/project_created.html:12
-#: hypha/apply/funds/tables.py:645
-msgid "Submission"
-msgstr "Einreichung"
+"Ein Projekt mit dem Titel „%(title)s“ wurde für Ihre Einreichung bei "
+"%(ORG_LONG_NAME)s erstellt."
 
 #: hypha/apply/activity/templates/messages/email/project_final_approval.html:7
-msgid "A Project is awaiting final approval."
-msgstr "Ein Projekt wartet auf die endgültige Genehmigung."
+#, python-format
+msgid "The project \"%(title)s\" is awaiting final approval."
+msgstr "Das Projekt „%(title)s“ wartet auf die endgültige Genehmigung."
+
+#: hypha/apply/activity/templates/messages/email/project_final_approval.html:9
+msgid "Approve the project here"
+msgstr "Das Projekt hier genehmigen"
 
 #: hypha/apply/activity/templates/messages/email/project_request_change.html:7
+#, python-format
 msgid ""
-"A Project has been rejected by project form reviewers, please update it "
-"accordingly and resubmit it to the reviewers."
+"The project forms for \"%(title)s\" was rejected by project form reviewers, "
+"please update it accordingly and resubmit it to the reviewers. "
 msgstr ""
-"Ein Projekt wurde von den Reviewer des Projektformulars abgelehnt. Bitte "
-"aktualisieren Sie es entsprechend und reichen Sie es erneut bei den "
-"Reviewern ein."
+"Das Projektformular für „%(title)s“ wurde von den Prüfern abgelehnt. Bitte "
+"aktualisieren Sie es entsprechend und reichen Sie es erneut bei den Prüfern "
+"ein. "
+
+#: hypha/apply/activity/templates/messages/email/project_request_change.html:10
+msgid "A comment was left that can be viewed here"
+msgstr "Es wurde ein Kommentar hinterlassen, der hier eingesehen werden kann"
 
 #: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:7
-msgid "A Project is waiting for contract"
-msgstr "Ein Projekt wartet auf einen Vertrag"
-
-#: hypha/apply/activity/templates/messages/email/ready_for_contracting.html:11
-#: hypha/apply/funds/models/utils.py:160
-#: hypha/apply/projects/templates/application_projects/paf_export.html:5
-msgid "Project Form"
-msgstr "Projektformular"
+#, python-format
+msgid "The project \"%(title)s\" is waiting for contract."
+msgstr "Das Projekt „%(title)s“ wartet auf den Vertrag."
 
 #: hypha/apply/activity/templates/messages/email/ready_for_invoicing.html:6
 #, python-format
@@ -1476,22 +1469,9 @@ msgstr ""
 "Der Vertrag für Ihr Projekt \"%(title)s\" wurde genehmigt. Jetzt ist Ihr "
 "Projekt bereit für die Rechnungsstellung."
 
-#: hypha/apply/activity/templates/messages/email/ready_for_invoicing.html:10
-msgid "Link to your project"
-msgstr "Link zu Ihrem Projekt"
-
-#: hypha/apply/activity/templates/messages/email/ready_for_invoicing.html:15
-#, python-format
-msgid ""
-"If you have any issues accessing the project or other general inquiries, "
-"please email us at %(ORG_EMAIL)s"
-msgstr ""
-"Wenn Sie Probleme beim Zugriff auf das Projekt oder andere allgemeine "
-"Anfragen haben, senden Sie uns bitte eine E-Mail an %(ORG_EMAIL)s"
-
 #: hypha/apply/activity/templates/messages/email/ready_to_review.html:6
 msgid "This application is awaiting your review."
-msgstr "Diese Einreichung wartet auf Ihre Bewertung."
+msgstr "Diese Einreichung wartet auf deine Bewertung."
 
 #: hypha/apply/activity/templates/messages/email/ready_to_review.html:9
 msgid "Reminder Title"
@@ -1505,10 +1485,10 @@ msgstr "Erinnerungsbeschreibung"
 #, python-format
 msgid ""
 "An %(ORG_SHORT_NAME)s staff member has changed the reporting frequency of "
-"%(title)s."
+"your project \"%(title)s\"."
 msgstr ""
-"Ein Teammitglied von %(ORG_SHORT_NAME)s hat die Berichtshäufigkeit von "
-"%(title)s geändert."
+"Ein Mitarbeiter von %(ORG_SHORT_NAME)s hat die Berichtsfrequenz Ihres "
+"Projekts „%(title)s“ geändert."
 
 #: hypha/apply/activity/templates/messages/email/report_frequency.html:8
 msgid "The new schedule is"
@@ -1520,12 +1500,8 @@ msgstr "Der nächste Bericht ist fällig"
 
 #: hypha/apply/activity/templates/messages/email/report_notify.html:6
 #, python-format
-msgid "A report is due for %(title)s on %(end_date)s."
-msgstr "Ein Bericht ist für %(title)s am %(end_date)s fällig."
-
-#: hypha/apply/activity/templates/messages/email/report_notify.html:8
-msgid "More information can be found on the project page:"
-msgstr "Weitere Informationen finden Sie auf der Projektseite:"
+msgid "A report is due for your project \"%(title)s\" on %(end_date)s."
+msgstr "Ein Bericht für Ihr Projekt „%(title)s“ ist am %(end_date)s fällig."
 
 #: hypha/apply/activity/templates/messages/email/report_skipped.html:6
 #, python-format
@@ -1542,8 +1518,8 @@ msgstr "erforderlich"
 
 #: hypha/apply/activity/templates/messages/email/report_skipped.html:6
 #, python-format
-msgid " for %(title)s for period %(start_date)s to %(end_date)s."
-msgstr " für %(title)s für den Zeitraum vom %(start_date)s bis %(end_date)s."
+msgid " for \"%(title)s\" for period %(start_date)s to %(end_date)s."
+msgstr " für \"%(title)s\" im Zeitraum von %(start_date)s bis %(end_date)s."
 
 #: hypha/apply/activity/templates/messages/email/report_skipped.html:9
 msgid ""
@@ -1556,21 +1532,29 @@ msgstr ""
 #: hypha/apply/activity/templates/messages/email/report_submitted.html:6
 #, python-format
 msgid ""
-"An %(ORG_SHORT_NAME)s staff member has submitted a report for %(title)s for "
-"period %(start_date)s to %(end_date)s."
+"An %(ORG_SHORT_NAME)s staff member has submitted a report for your project "
+"\"%(title)s\" for period %(start_date)s to %(end_date)s."
 msgstr ""
-"Ein Teammitglied von %(ORG_SHORT_NAME)s hat einen Bericht für %(title)s für "
-"den Zeitraum %(start_date)s bis %(end_date)s eingereicht."
+"Ein Mitarbeiter von %(ORG_SHORT_NAME)s hat einen Bericht für Ihr Projekt "
+"„%(title)s” für den Zeitraum von %(start_date)s bis %(end_date)s eingereicht."
 
 #: hypha/apply/activity/templates/messages/email/report_submitted.html:8
 msgid "You can review the report here"
 msgstr "Sie können den Bericht hier überprüfen"
 
+#: hypha/apply/activity/templates/messages/email/sent_to_compliance.html:7
+#, python-format
+msgid "The project \"%(title)s\" is awaiting your review."
+msgstr "Das Projekt „%(title)s“ wartet auf Ihre Überprüfung."
+
 #: hypha/apply/activity/templates/messages/email/submission_confirmation.html:6
 #, python-format
 msgid ""
-"We appreciate your %(title)s application submission to the %(ORG_LONG_NAME)s."
-msgstr "Vielen Dank für Ihre Einreichung %(title)s beim %(ORG_LONG_NAME)s."
+"We appreciate your \"%(title)s\" application submission to the "
+"%(ORG_LONG_NAME)s."
+msgstr ""
+"Wir freuen uns über Ihre Bewerbung für die Position „%(title)s“ bei "
+"%(ORG_LONG_NAME)s."
 
 #: hypha/apply/activity/templates/messages/email/submission_confirmation.html:8
 msgid ""
@@ -1588,7 +1572,7 @@ msgid "We will review and reply to your submission as quickly as possible."
 msgstr ""
 "Wir werden Ihre Einreichung überprüfen und so schnell wie möglich antworten."
 
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:12
+#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:14
 #, python-format
 msgid ""
 "If you have issues accessing the submission system or general inquiries, "
@@ -1597,7 +1581,7 @@ msgstr ""
 "Wenn Sie Probleme beim Zugriff auf das Einreichungssystem oder allgemeine "
 "Anfragen haben, senden Sie uns bitte eine E-Mail an %(ORG_EMAIL)s."
 
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:14
+#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:16
 #, python-format
 msgid ""
 "For more information about our support options, review process, and "
@@ -1607,21 +1591,15 @@ msgstr ""
 "Bewertungsprozess und unseren Auswahlkriterien besuchen Sie bitte unsere "
 "Website unter %(ORG_URL)s."
 
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:18
-#: hypha/apply/projects/templates/application_projects/paf_export.html:7
-#: hypha/apply/projects/templates/application_projects/sow_export.html:7
-msgid "Project ID"
-msgstr "Projekt-ID"
-
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:19
+#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:20
 msgid "Project name"
 msgstr "Projektname"
 
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:20
+#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:21
 msgid "Contact name"
 msgstr "Kontaktname"
 
-#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:21
+#: hypha/apply/activity/templates/messages/email/submission_confirmation.html:22
 msgid "Contact email"
 msgstr "Kontakt-E-Mail"
 
@@ -1629,46 +1607,60 @@ msgstr "Kontakt-E-Mail"
 msgid "Your submission has been edited by a member of staff."
 msgstr "Ihre Einreichung wurde von einem Mitarbeiter bearbeitet."
 
-#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:9
-msgid "A Project's contract is awaiting your review."
-msgstr "Der Vertrag eines Projekts wartet auf Ihre Bewertung."
+#: hypha/apply/activity/templates/messages/email/submit_contract_documents.html:8
+#, python-format
+msgid "The contract for project \"%(title)s\" is awaiting your review."
+msgstr "Der Vertrag für Projekt \"%(title)s\" wartet auf deine Prüfung."
 
 #: hypha/apply/activity/templates/messages/email/transition.html:6
 #, python-format
 msgid ""
-"Your application is now in \"%(new_status)s\" status (progressed from "
-"\"%(old_status)s\")."
+"Your application is now in \"%(new_phase)s\" status (progressed from "
+"\"%(old_phase)s\")."
 msgstr ""
-"Ihre Einreichung hat jetzt den Status \"%(new_status)s\" (geändert von "
-"\"%(old_status)s\")."
+"Ihr Antrag befindet sich jetzt im Status \"%(new_phase)s\" (von "
+"\"%(old_phase)s\" fortgeschoben)."
 
 #: hypha/apply/activity/templates/messages/email/transition.html:8
 msgid "Please submit any questions related to your application here"
 msgstr "Bitte senden Sie alle Fragen zu Ihrer Einreichung an"
 
-#: hypha/apply/activity/templatetags/activity_tags.py:42
-#: hypha/apply/funds/tables.py:621
-#: hypha/apply/funds/templates/funds/includes/review_sidebar_item.html:11
-#: hypha/apply/funds/templates/funds/includes/review_sidebar_item.html:27
-#: hypha/apply/funds/templates/funds/includes/review_sidebar_item.html:41
-#: hypha/apply/review/templates/review/review_detail.html:16
+#: hypha/apply/activity/templatetags/activity_tags.py:50
+#: hypha/apply/funds/tables.py:537
+#: hypha/apply/funds/templates/funds/includes/review_sidebar_item.html:12
+#: hypha/apply/funds/templates/funds/includes/review_sidebar_item.html:28
+#: hypha/apply/funds/templates/funds/includes/review_sidebar_item.html:44
+#: hypha/apply/review/templates/review/review_detail.html:11
 #: hypha/apply/users/roles.py:7
 msgid "Reviewer"
 msgstr "Reviewer"
 
-#: hypha/apply/activity/templatetags/activity_tags.py:50
-#: hypha/apply/funds/templates/funds/tables/table.html:21
-#: hypha/apply/funds/templatetags/workflow_tags.py:68
+#: hypha/apply/activity/templatetags/activity_tags.py:61
+#: hypha/apply/funds/templatetags/workflow_tags.py:72
 #: hypha/apply/users/roles.py:5
 msgid "Applicant"
 msgstr "Bewerber"
+
+#: hypha/apply/activity/templatetags/activity_tags.py:200
+msgid ""
+"No action is needed for now, you will be notified when a contract is ready "
+"for you to sign."
+msgstr ""
+"Vorerst ist keine Maßnahme erforderlich, Sie werden benachrichtigt, sobald "
+"ein Vertrag fertig zur Unterzeichnung ist."
+
+#: hypha/apply/activity/templatetags/activity_tags.py:203
+msgid "You can begin submitting invoices and reports for your project."
+msgstr ""
+"Sie können damit beginnen, Rechnungen und Berichte für Ihr Projekt "
+"einzureichen."
 
 #: hypha/apply/categories/blocks.py:31
 msgid "Multi select"
 msgstr "Mehrfachauswahl"
 
-#: hypha/apply/categories/blocks.py:35 hypha/apply/funds/blocks.py:31
-#: hypha/apply/funds/blocks.py:73 hypha/apply/funds/blocks.py:119
+#: hypha/apply/categories/blocks.py:35 hypha/apply/funds/blocks.py:32
+#: hypha/apply/funds/blocks.py:80 hypha/apply/funds/blocks.py:126
 #: hypha/apply/stream_forms/blocks.py:36
 msgid "Label"
 msgstr "Beschriftung"
@@ -1677,8 +1669,8 @@ msgstr "Beschriftung"
 msgid "Leave blank to use the default Category label"
 msgstr "Leeren lassen, um das Standard-Kategorielabel zu verwenden"
 
-#: hypha/apply/categories/blocks.py:40 hypha/apply/funds/blocks.py:35
-#: hypha/apply/funds/blocks.py:77 hypha/apply/funds/blocks.py:122
+#: hypha/apply/categories/blocks.py:40 hypha/apply/funds/blocks.py:36
+#: hypha/apply/funds/blocks.py:84 hypha/apply/funds/blocks.py:129
 #: hypha/apply/stream_forms/blocks.py:37
 msgid "Help text"
 msgstr "Hilfetext"
@@ -1720,10 +1712,10 @@ msgstr "Für Bewerber bereitstellen"
 msgid "Tag"
 msgstr "Tag"
 
-#: hypha/apply/categories/models.py:140 hypha/apply/funds/forms.py:410
-#: hypha/apply/funds/tables.py:352
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:98
-#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:4
+#: hypha/apply/categories/models.py:140 hypha/apply/funds/forms.py:413
+#: hypha/apply/funds/tables.py:283
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:127
+#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:5
 msgid "Tags"
 msgstr "Tag"
 
@@ -1735,73 +1727,81 @@ msgstr "archiviert"
 #: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:5
 #: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:10
 #: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:5
-#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:9
+#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:10
 #: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:5
 #: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:9
 #: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:5
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:11
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:10
 #: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:5
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:10
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:9
 #: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:5
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:9
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:10
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:11
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:10
 msgid "My dashboard"
 msgstr "Mein Dashboard"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:12
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:11
 msgid "An overview of active and past submissions and projects"
 msgstr "Eine Übersicht über aktive und vergangene Einreichungen und Projekte"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:16
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:14
-#: hypha/apply/users/templates/users/account.html:20
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:15
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:15
+#: hypha/apply/users/templates/users/account.html:21
 msgid "Submit a new application"
 msgstr "Eine neue Bewerbung einreichen"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:17
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:15
-#: hypha/apply/users/templates/users/account.html:21
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:16
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:16
+#: hypha/apply/users/templates/users/account.html:22
 msgid "Apply now for our open rounds"
 msgstr "Bewerben Sie sich jetzt für unsere offenen Runden"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:20
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:16
-#: hypha/apply/users/templates/users/account.html:24
-#: hypha/home/templates/home/includes/fund-list-item.html:31
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:23
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:20
+#: hypha/apply/users/templates/users/account.html:26
+#: hypha/home/templates/home/includes/fund-list-item.html:33
 msgid "Apply"
 msgstr "Jetzt bewerben"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:34
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:39
 msgid "My submissions"
 msgstr "Meine Einreichungen"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:51
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:59
 msgid "My projects"
 msgstr "Meine Projekte"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:67
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:80
 msgid "My active invoices"
 msgstr "Meine aktiven Rechnungen"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:76
-msgid "Date added: "
-msgstr "Datum hinzugefügt: "
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:91
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:76
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:24
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:41
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:68
+#: hypha/apply/funds/tables.py:69 hypha/apply/projects/models/payment.py:26
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:56
+#: hypha/apply/projects/tables.py:44
+msgid "Submitted"
+msgstr "Eingereicht"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:93
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:115
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:45
 msgid "No active invoices"
 msgstr "Keine aktiven Rechnungen"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:101
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:89
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:58
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:80
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:125
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:106
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:66
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:89
 msgid "Submission history"
 msgstr "Einreichungshistorie"
 
-#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:108
+#: hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html:136
 msgid "Project history"
 msgstr "Projektverlauf"
 
@@ -1809,244 +1809,253 @@ msgstr "Projektverlauf"
 msgid "An overview of active and past submissions"
 msgstr "Eine Übersicht über aktive und vergangene Einreichungen"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:24
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:32
 msgid "Community review submissions"
 msgstr "Community Bewertung Beiträge"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:30
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:26
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:41
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:29
 msgid "No submissions"
 msgstr "Keine Einreichungen"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:37
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:37
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:59
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:120
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:48
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:44
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:65
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:139
 msgid "Your previous reviews"
 msgstr "Ihre vorherigen Bewertungen"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:45
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:31
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:52
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:62
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:34
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:61
 msgid "Your active submissions"
 msgstr "Ihre aktiven Einreichungen"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:59
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:37
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:59
-#: hypha/apply/funds/tables.py:84
-#: hypha/apply/funds/templates/funds/revisions_compare.html:24
-#: hypha/apply/funds/templates/funds/revisions_compare.html:28
-#: hypha/apply/projects/models/payment.py:27 hypha/apply/projects/tables.py:45
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:57
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:68
-msgid "Submitted"
-msgstr "Eingereicht"
-
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:59
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:20
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:37
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:59
-#: hypha/apply/determinations/templates/determinations/includes/applicant_determination_block.html:10
-#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:9
-#: hypha/apply/funds/templates/funds/applicationrevision_list.html:17
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:86
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:93
-#: hypha/apply/funds/templates/funds/tables/table.html:30
-#: hypha/apply/review/templates/review/review_detail.html:14
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:76
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:30
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:41
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:68
+#: hypha/apply/determinations/templates/determinations/includes/applicant_determination_block.html:11
+#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:18
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:90
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:98
+#: hypha/apply/funds/templates/funds/includes/submission-list-row.html:79
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:28
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:40
+#: hypha/apply/review/templates/review/review_detail.html:11
 msgid "by"
 msgstr "durch"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:66
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:83
 msgid "Start your"
 msgstr "Beginnen Sie Ihr"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:66
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:83
 msgid "application"
 msgstr "Anwendung"
 
-#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:82
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:44
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:52
+#: hypha/apply/dashboard/templates/dashboard/community_dashboard.html:99
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:71
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:57
 msgid "No active submissions"
 msgstr "Keine aktiven Einreichungen"
 
-#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:14
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:14
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:15
-#: hypha/apply/users/templates/users/account.html:32
+#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:15
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:13
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:16
+#: hypha/apply/users/templates/users/account.html:35
 #: hypha/templates/includes/user_menu.html:57
 msgid "Administration"
 msgstr "Verwaltung"
 
-#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:27
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:96
+#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:30
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:93
 msgid "PAFs for review"
 msgstr "PAFs zur Bewertung"
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:27
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:37
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:38
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:60
-#: hypha/apply/funds/tables.py:562
-#: hypha/apply/users/templates/wagtailusers/users/list.html:58
-msgid "Active"
-msgstr "Aktiv"
+#: hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html:37
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:99
+msgid "You don't have any PAFs for review right now"
+msgstr "Du hast momentan keine PAFs zur Überprüfung"
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:30
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:5
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:27
+#: hypha/apply/funds/models/co_applicants.py:16
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:6
 #: hypha/apply/projects/templates/application_projects/invoice_list.html:6
-#: hypha/apply/projects/views/project_partials.py:149
-#: hypha/core/navigation.py:88
+#: hypha/core/navigation.py:109
 msgid "Invoices"
 msgstr "Rechnungen"
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:39
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:113
-msgid "Active Invoices"
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:34
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:127
+msgid "Active invoices"
 msgstr "Aktive Rechnungen"
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:45
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:46
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:47
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:71
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:55
 msgid "For Approval"
 msgstr "Zur Genehmigung"
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:53
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:54
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:55
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:82
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:65
+msgid "No invoices for Approval "
+msgstr "Keine Rechnungen zur Genehmigung "
+
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:75
 msgid "For Conversion"
 msgstr "Für Umrechnung"
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:65
-msgid "No Active Invoices"
-msgstr "Keine aktiven Rechnungen"
+#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:85
+msgid "No invoices for conversion "
+msgstr "Keine Rechnungen für die Umwandlung "
 
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:76
-msgid "No Invoices for Approval "
-msgstr "Keine Rechnungen zur Prüfung "
-
-#: hypha/apply/dashboard/templates/dashboard/finance_dashboard.html:87
-msgid "No Invoices for Conversion "
-msgstr "Keine Rechnungen für die Umrechnung "
-
-#: hypha/apply/dashboard/templates/dashboard/includes/my-tasks.html:5
+#: hypha/apply/dashboard/templates/dashboard/includes/my-tasks.html:6
 msgid "My tasks"
 msgstr "Meine Aufgaben"
 
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:4
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:15
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:16
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:17
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:29
-msgid "Waiting for contract"
-msgstr "Warten auf Vertrag"
-
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:7
+#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:6
 msgid "Projects in contracting"
 msgstr "Projekte im Auftrag"
 
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:23
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:24
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:25
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:38
-msgid "Waiting for contract approval"
-msgstr "Warten auf Vertragsgenehmigung"
+#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:14
+msgid "Waiting for contract"
+msgstr "Warten auf Vertrag"
 
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:34
+#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:25
 msgid "No project is waiting for contract"
 msgstr "Kein Projekt wartet auf einen Vertrag"
 
-#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:43
-msgid "No project is waiting for contract approval "
-msgstr "Es wartet kein Projekt auf Vertragsfreigabe "
+#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:34
+msgid "Waiting for contract approval"
+msgstr "Warten auf Vertragsgenehmigung"
+
+#: hypha/apply/dashboard/templates/dashboard/includes/projects_in_contracting.html:44
+msgid "No project is waiting for contract approval"
+msgstr "Kein Projekt wartet auf die Vertragsgenehmigung"
 
 #: hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html:5
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:29
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:35
 msgid "Submissions waiting for your review"
 msgstr "Einreichungen warten auf Ihre Überprüfung"
-
-#: hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html:16
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:43
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:106
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:125
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:34
-msgid "Show all"
-msgstr "Zeige alles"
 
 #: hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html:22
 msgid "Nice! You're all caught up. 🎉"
 msgstr "Super! Sie sind jetzt auf dem neuesten Stand. 🎉"
 
-#: hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html:23
+#: hypha/apply/dashboard/templates/dashboard/includes/submissions-waiting-for-review.html:27
 msgid "Find new applications to review"
 msgstr "Finde neue Anträge zur Bewertung"
 
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_projects.html:8
-msgid "Project start date: "
-msgstr "Projektstartdatum: "
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_projects.html:13
+msgid "Project started "
+msgstr "Projekt gestartet "
 
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_projects.html:14
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_projects.html:23
 msgid "No active projects"
 msgstr "Keine aktiven Projekte"
 
 #: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:16
-msgid "Drafted on "
-msgstr "Entworfen am "
+#: hypha/apply/determinations/models.py:117
+#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:12
+#: hypha/apply/funds/templates/funds/includes/application_header.html:7
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:25
+#: hypha/apply/funds/workflows/definitions/double_stage.py:26
+#: hypha/apply/funds/workflows/definitions/single_stage.py:25
+#: hypha/apply/funds/workflows/definitions/single_stage_community.py:27
+#: hypha/apply/funds/workflows/definitions/single_stage_external.py:26
+#: hypha/apply/funds/workflows/definitions/single_stage_same.py:26
+#: hypha/apply/projects/models/project.py:85
+#: hypha/apply/projects/models/project.py:93 hypha/apply/review/models.py:172
+#: hypha/apply/todo/options.py:73 hypha/apply/todo/options.py:81
+#: hypha/apply/todo/options.py:89
+msgid "Draft"
+msgstr "Entwurf"
 
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:18
-msgid "Submitted on "
-msgstr "Eingereicht am "
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:22
+msgid "Drafted"
+msgstr "Entwurf"
 
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:25
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:44
-#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:66
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:60
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:37
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:48
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:75
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:64
 msgctxt "start application"
 msgid "Start"
 msgstr "Starten"
 
-#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:36
-#: hypha/apply/funds/templates/funds/applicationsubmission_confirm_delete.html:42
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:109
+#: hypha/apply/dashboard/templates/dashboard/partials/applicant_submissions.html:59
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:126
 #: hypha/apply/funds/templates/funds/includes/delegated_form_base.html:33
-#: hypha/apply/funds/templates/funds/includes/reminders_block.html:20
-#: hypha/apply/funds/templates/funds/includes/reminders_block.html:25
-#: hypha/apply/funds/templates/submissions/all.html:533
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:34
-#: hypha/apply/projects/views/payment.py:331
-#: hypha/apply/review/templates/review/review_detail.html:50
+#: hypha/apply/funds/templates/funds/includes/reminders_block.html:21
+#: hypha/apply/funds/templates/funds/includes/reminders_block.html:26
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:75
+#: hypha/apply/funds/templates/submissions/all.html:500
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:59
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:40
+#: hypha/apply/projects/views/payment.py:355
+#: hypha/apply/review/templates/review/review_detail.html:92
+#: hypha/templates/cotton/modal/confirm.html:42
 #: hypha/templates/includes/dialog_form_base.html:28
 msgid "Delete"
 msgstr "Löschen"
 
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:12
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:10
-#: hypha/apply/users/templates/users/account.html:8
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:11
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:11
+#: hypha/apply/users/templates/users/account.html:9
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:20
+#: hypha/apply/dashboard/templates/dashboard/partner_dashboard.html:21
 msgid "You are the partner of these submissions"
 msgstr "Sie sind der Partner dieser Einreichungen"
 
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:37
+#: hypha/apply/dashboard/templates/dashboard/reviewer_dashboard.html:23
+#: hypha/apply/funds/templates/submissions/all.html:87
+msgid "Your flagged submissions"
+msgstr "Ihre gekennzeichneten Einreichungen"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:38
+msgid "View submissions waiting for your review"
+msgstr "Sehen Sie sich Einsendungen an, die auf Ihre Bewertung warten"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:43
 msgid "Live projects under your management"
 msgstr "Laufende Projekte unter Ihrer Leitung"
 
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:44
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:46
+msgid "View live projects under your management"
+msgstr "Sehen Sie sich Live-Projekte unter Ihrer Leitung an"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:50
 msgid "Requests for invoices requiring your attention"
 msgstr "Anfragen für Rechnungen, die Ihre Aufmerksamkeit erfordern"
 
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:92
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:53
+msgid "View invoice requests requiring your attention"
+msgstr "Sehen Sie sich Rechnungsanfragen an, die Ihre Aufmerksamkeit erfordern"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:58
+msgid "Submissions flagged by you"
+msgstr "Von dir markierte Einreichungen"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:61
+msgid "View submissions flagged by you"
+msgstr "Sehen Sie sich von Ihnen markierte Einsendungen an"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:68
+msgid "View your previous reviews"
+msgstr "Sehen Sie sich Ihre bisherigen Bewertungen an"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:104
 msgid "Project forms for review"
 msgstr "Projektformulare zur Überprüfung"
 
-#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:100
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:113
 msgid "Your projects"
 msgstr "Ihre Projekte"
+
+#: hypha/apply/dashboard/templates/dashboard/staff_dashboard.html:120
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:80
+msgid "Show all"
+msgstr "Zeige alles"
 
 #: hypha/apply/dashboard/wagtail_hooks.py:10
 msgid "Goto Dashboard"
@@ -2060,12 +2069,11 @@ msgstr "Benachrichtigung senden"
 #: hypha/apply/determinations/blocks.py:77
 #: hypha/apply/determinations/blocks.py:78
 #: hypha/apply/determinations/blocks.py:79
-#: hypha/apply/determinations/blocks.py:80 hypha/apply/funds/blocks.py:215
-#: hypha/apply/review/blocks.py:169 hypha/apply/review/blocks.py:170
-#: hypha/apply/review/blocks.py:171 hypha/apply/review/blocks.py:172
-#: hypha/apply/review/blocks.py:173 hypha/apply/review/blocks.py:174
-#: hypha/apply/review/blocks.py:175 hypha/apply/stream_forms/blocks.py:474
-#: hypha/apply/stream_forms/blocks.py:475
+#: hypha/apply/determinations/blocks.py:80 hypha/apply/funds/blocks.py:229
+#: hypha/apply/review/blocks.py:172 hypha/apply/review/blocks.py:173
+#: hypha/apply/review/blocks.py:174 hypha/apply/review/blocks.py:175
+#: hypha/apply/review/blocks.py:176 hypha/apply/review/blocks.py:177
+#: hypha/apply/review/blocks.py:178 hypha/apply/stream_forms/blocks.py:475
 #: hypha/apply/stream_forms/blocks.py:476
 #: hypha/apply/stream_forms/blocks.py:477
 #: hypha/apply/stream_forms/blocks.py:478
@@ -2077,18 +2085,19 @@ msgstr "Benachrichtigung senden"
 #: hypha/apply/stream_forms/blocks.py:484
 #: hypha/apply/stream_forms/blocks.py:485
 #: hypha/apply/stream_forms/blocks.py:486
-#: hypha/apply/stream_forms/blocks.py:487 hypha/apply/utils/blocks.py:74
+#: hypha/apply/stream_forms/blocks.py:487
+#: hypha/apply/stream_forms/blocks.py:488 hypha/apply/utils/blocks.py:74
 #: hypha/apply/utils/blocks.py:75
 msgid "Fields"
 msgstr "Felder"
 
-#: hypha/apply/determinations/blocks.py:78 hypha/apply/review/blocks.py:171
-#: hypha/apply/stream_forms/blocks.py:472
+#: hypha/apply/determinations/blocks.py:78 hypha/apply/review/blocks.py:174
+#: hypha/apply/stream_forms/blocks.py:473
 msgid "Paragraph"
 msgstr "Absatz"
 
 #: hypha/apply/determinations/forms.py:109
-#: hypha/apply/determinations/views.py:91
+#: hypha/apply/determinations/views.py:92
 msgid "-- No determination selected -- "
 msgstr "-- Kein Entscheidung ausgewählt -- "
 
@@ -2096,15 +2105,14 @@ msgstr "-- Kein Entscheidung ausgewählt -- "
 #: hypha/apply/determinations/forms.py:256
 #: hypha/apply/determinations/forms.py:580
 #: hypha/apply/determinations/models.py:108
-#: hypha/apply/determinations/templates/determinations/determination_detail.html:14
-#: hypha/apply/determinations/templates/determinations/determination_detail.html:21
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:11
 msgid "Determination"
 msgstr "Entscheidung"
 
 #: hypha/apply/determinations/forms.py:184
 #: hypha/apply/determinations/forms.py:262
 #: hypha/apply/determinations/models.py:110
-#: hypha/apply/determinations/templates/determinations/determination_detail.html:33
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:44
 msgid "Determination message"
 msgstr "Entscheidungsmitteilung"
 
@@ -2185,41 +2193,27 @@ msgid "Rationale and appropriateness questions and comments"
 msgstr "Begründung und Angemessenheitsfragen und -kommentare"
 
 #: hypha/apply/determinations/forms.py:376
-#: hypha/apply/determinations/views.py:377
+#: hypha/apply/determinations/views.py:378
 msgid "-- No proposal form selected -- "
 msgstr "-- Kein Vorschlagsformular ausgewählt -- "
 
 #: hypha/apply/determinations/forms.py:379
-#: hypha/apply/determinations/views.py:380
+#: hypha/apply/determinations/views.py:381
 msgid "Select the proposal form only for determination approval"
 msgstr ""
 "Wählen Sie das Formular zum Konzept nur für die Entscheidungsgenehmigung"
 
 #: hypha/apply/determinations/forms.py:383
-#: hypha/apply/determinations/views.py:384
+#: hypha/apply/determinations/views.py:385
 msgid "Select the proposal form to use for proposal stage."
 msgstr ""
 "Wählen Sie das Formular zum Konzept, das für die Konzeptphase verwendet "
 "werden soll."
 
 #: hypha/apply/determinations/forms.py:386
-#: hypha/apply/determinations/views.py:387
+#: hypha/apply/determinations/views.py:388
 msgid "Proposal Form"
 msgstr "Formular zum Konzept"
-
-#: hypha/apply/determinations/models.py:117
-#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:7
-#: hypha/apply/funds/workflows/definitions/double_stage.py:26
-#: hypha/apply/funds/workflows/definitions/single_stage.py:25
-#: hypha/apply/funds/workflows/definitions/single_stage_community.py:27
-#: hypha/apply/funds/workflows/definitions/single_stage_external.py:26
-#: hypha/apply/funds/workflows/definitions/single_stage_same.py:26
-#: hypha/apply/projects/models/project.py:82
-#: hypha/apply/projects/models/project.py:90 hypha/apply/review/models.py:172
-#: hypha/apply/todo/options.py:69 hypha/apply/todo/options.py:77
-#: hypha/apply/todo/options.py:85
-msgid "Draft"
-msgstr "Entwurf"
 
 #: hypha/apply/determinations/models.py:119 hypha/apply/review/models.py:174
 msgid "Creation time"
@@ -2254,7 +2248,9 @@ msgid "Proposal form"
 msgstr "Formular zum Konzept"
 
 #: hypha/apply/determinations/options.py:10
-#: hypha/apply/funds/workflows/constants.py:93
+#: hypha/apply/funds/workflows/constants.py:95
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:110
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:197
 #: hypha/apply/funds/workflows/definitions/double_stage.py:147
 #: hypha/apply/funds/workflows/definitions/double_stage.py:326
 #: hypha/apply/funds/workflows/definitions/single_stage.py:149
@@ -2273,8 +2269,9 @@ msgid "Edit a Determination"
 msgstr "Eine Entscheidung bearbeiten"
 
 #: hypha/apply/determinations/templates/determinations/base_determination_form.html:3
-#: hypha/apply/determinations/templates/determinations/determination_form.html:6
-#: hypha/apply/funds/templates/funds/applicationrevision_list.html:22
+#: hypha/apply/funds/templates/funds/applicationrevision_list.html:33
+#: hypha/apply/funds/templates/funds/revisions_compare.html:102
+#: hypha/apply/funds/templates/funds/revisions_compare.html:127
 msgid "draft"
 msgstr "Entwurf"
 
@@ -2282,95 +2279,82 @@ msgstr "Entwurf"
 msgid "Create a Determination"
 msgstr "Erstellen Sie eine Entscheidung"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:8
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:9
 msgid "Update Determination draft"
 msgstr "Entscheidungsentwurf aktualisieren"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:8
-#: hypha/apply/determinations/templates/determinations/determination_form.html:6
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:9
 msgid "Create Determination"
 msgstr "Erstellung der Entscheidung"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:9
-#: hypha/apply/determinations/templates/determinations/determination_detail.html:15
-#: hypha/apply/determinations/templates/determinations/determination_form.html:8
-#: hypha/apply/funds/templates/funds/applicationrevision_list.html:8
-#: hypha/apply/funds/templates/funds/revisions_compare.html:15
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:15
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:16
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:25
-#: hypha/apply/review/templates/review/review_detail.html:14
-#: hypha/apply/review/templates/review/review_edit_form.html:15
-#: hypha/apply/review/templates/review/review_form.html:15
-#: hypha/apply/review/templates/review/review_list.html:11
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:10
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:12
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:12
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:15
+#: hypha/apply/review/templates/review/review_detail.html:11
+#: hypha/apply/review/templates/review/review_edit_form.html:14
+#: hypha/apply/review/templates/review/review_list.html:10
 msgid "For"
 msgstr "Für"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:16
-#: hypha/apply/review/templates/review/review_form.html:23
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:22
+#: hypha/apply/review/templates/review/review_form.html:28
 msgid "Show application"
 msgstr "Einreichungen anzeigen"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:17
-#: hypha/apply/review/templates/review/review_form.html:24
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:26
+#: hypha/apply/review/templates/review/review_form.html:32
 msgid "Hide application"
 msgstr "Einreichung ausblenden"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:57
-#: hypha/apply/funds/templates/funds/application_base.html:75
-#: hypha/apply/funds/templates/funds/applicationsubmission_form.html:35
-#: hypha/apply/funds/views/submission_edit.py:130
-#: hypha/apply/funds/views/submission_edit.py:133
-#: hypha/apply/funds/views/submission_edit.py:318
-#: hypha/apply/projects/templates/application_projects/project_approval_form.html:41
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:39
-#: hypha/apply/projects/templates/application_projects/report_form.html:56
-#: hypha/apply/review/templates/review/review_edit_form.html:72
-#: hypha/apply/review/templates/review/review_form.html:71
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:85
+#: hypha/apply/funds/templates/funds/application_base.html:117
+#: hypha/apply/funds/templates/funds/applicationsubmission_form.html:44
+#: hypha/apply/funds/views/submission_edit.py:123
+#: hypha/apply/funds/views/submission_edit.py:126
+#: hypha/apply/funds/views/submission_edit.py:305
+#: hypha/apply/projects/reports/templates/reports/report_form.html:69
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:52
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:48
+#: hypha/apply/review/templates/review/review_edit_form.html:75
+#: hypha/apply/review/templates/review/review_form.html:88
 msgid "Save draft"
 msgstr "Entwurf speichern"
 
-#: hypha/apply/determinations/templates/determinations/base_determination_form.html:82
-#: hypha/apply/funds/templates/funds/comments.html:101
-#: hypha/apply/review/templates/review/review_form.html:96
-#: hypha/core/templates/components/dropdown-menu.html:90
+#: hypha/apply/determinations/templates/determinations/base_determination_form.html:108
+#: hypha/apply/funds/templates/funds/comments.html:108
+#: hypha/apply/review/templates/review/review_form.html:107
+#: hypha/core/templates/components/dropdown-menu.html:91
 msgid "Loading…"
 msgstr "Wird geladen…"
 
 #: hypha/apply/determinations/templates/determinations/batch_determination_form.html:10
-msgid "Add Batch Determination"
-msgstr "Add Batch Determination"
+msgid "Add batch determination"
+msgstr "Hinzufügen der Chargenbestimmung"
 
-#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:17
+#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:18
 msgid "Determining"
 msgstr "Determining"
 
-#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:17
+#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:18
 msgid "submission"
 msgstr "Einreichung"
 
-#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:17
+#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:18
 #: hypha/apply/projects/templates/application_projects/paf_export.html:41
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:66
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:75
 msgid "as"
 msgstr "als"
 
-#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:18
-#: hypha/apply/funds/templates/funds/tables/table.html:127
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:42
-#: hypha/apply/projects/templates/application_projects/tables/table.html:21
-msgid "Show"
-msgstr "Anzeigen"
-
-#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:32
+#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:42
 msgid ""
 "This determination message will be emailed to applicants and cannot be "
-"undone. Do you wish to contiune?"
+"undone. Do you wish to continue?"
 msgstr ""
-"Diese Entscheidungsnachricht wird an Bewerber per E-Mail gesendet und kann "
-"nicht rückgängig gemacht werden. Möchten Sie fortfahren?"
+"Diese Entscheidung wird an die Bewerber per E-Mail gesendet und kann nicht "
+"rückgängig gemacht werden. Möchten Sie weitermachen?"
 
-#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:33
+#: hypha/apply/determinations/templates/determinations/batch_determination_form.html:43
 msgid "Send"
 msgstr "Senden"
 
@@ -2379,68 +2363,78 @@ msgid "Determination for"
 msgstr "Entscheidung für"
 
 #: hypha/apply/determinations/templates/determinations/determination_detail.html:10
+#: hypha/apply/funds/templates/funds/applicationrevision_list.html:11
+#: hypha/apply/funds/templates/funds/submission_sealed.html:49
 #: hypha/apply/review/templates/review/review_detail.html:9
-msgid "View submission"
-msgstr "Bewerbung anzeigen"
+msgid "View application"
+msgstr "Einreichung anzeigen"
 
-#: hypha/apply/determinations/templates/determinations/determination_detail.html:14
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:11
 msgid "DRAFT"
 msgstr "ENTWURF"
 
-#: hypha/apply/determinations/templates/determinations/determination_form.html:6
-msgid "Edit determination"
-msgstr "Bearbeiten der Entscheidung"
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:22
+msgid "Outcome"
+msgstr "Ergebnis"
 
-#: hypha/apply/determinations/templates/determinations/includes/applicant_determination_block.html:3
-#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:3
+#: hypha/apply/determinations/templates/determinations/determination_detail.html:34
+#: hypha/apply/funds/templates/funds/application_preview.html:66
+#: hypha/apply/funds/templates/funds/submission-success.html:61
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:88
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:96
+msgid "Continue editing"
+msgstr "Weiter bearbeiten"
+
+#: hypha/apply/determinations/templates/determinations/includes/applicant_determination_block.html:4
+#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:5
 msgid "Determinations"
 msgstr "Entscheidungen"
 
-#: hypha/apply/determinations/templates/determinations/includes/applicant_determination_block.html:13
-#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:12
+#: hypha/apply/determinations/templates/determinations/includes/applicant_determination_block.html:14
+#: hypha/apply/determinations/templates/determinations/includes/determination_block.html:22
 msgid "Awaiting determination"
 msgstr "Entscheidung steht noch aus"
 
-#: hypha/apply/determinations/templates/determinations/includes/determination_button.html:8
+#: hypha/apply/determinations/templates/determinations/includes/determination_button.html:11
 msgid "Update draft"
 msgstr "Entwurf aktualisieren"
 
-#: hypha/apply/determinations/templates/determinations/includes/determination_button.html:11
+#: hypha/apply/determinations/templates/determinations/includes/determination_button.html:14
 msgid "Add determination"
 msgstr "Entscheidung hinzufügen"
 
-#: hypha/apply/determinations/views.py:112
+#: hypha/apply/determinations/views.py:113
 msgid "Improperly configured request, please try again."
 msgstr "Falsch konfigurierte Anfrage, bitte versuchen Sie es erneut."
 
-#: hypha/apply/determinations/views.py:205
+#: hypha/apply/determinations/views.py:206
 #, python-brace-format
 msgid "Successfully determined as {outcome}: "
 msgstr "Erfolgreich als {outcome} ermittelt: "
 
-#: hypha/apply/determinations/views.py:226
+#: hypha/apply/determinations/views.py:227
 #, python-brace-format
 msgid "Unable to determine submission \"{title}\" as already determined"
 msgstr ""
 "Konnte die Einreichung \"{title}\" nicht als bereits bestimmt ermitteln"
 
-#: hypha/apply/determinations/views.py:278
+#: hypha/apply/determinations/views.py:279
 msgid "You do not have permission to create that determination."
 msgstr "Sie haben keine Berechtigung, um diese Entscheidung zu erstellen."
 
-#: hypha/apply/determinations/views.py:283
+#: hypha/apply/determinations/views.py:284
 msgid "A final determination has already been submitted."
 msgstr "Eine endgültige Entscheidung wurde bereits eingereicht."
 
-#: hypha/apply/determinations/views.py:296
+#: hypha/apply/determinations/views.py:297
 msgid "There is a draft determination you do not have permission to edit."
 msgstr "Es gibt eine Entwurfsentscheidung, die Sie nicht bearbeiten dürfen."
 
-#: hypha/apply/determinations/views.py:444
+#: hypha/apply/determinations/views.py:445
 msgid "A project was automatically created."
 msgstr "Ein Projekt wurde automatisch erstellt."
 
-#: hypha/apply/determinations/views.py:488
+#: hypha/apply/determinations/views.py:492
 #, python-brace-format
 msgid ""
 "A determination of \"{current}\" exists but you tried to progress as "
@@ -2485,15 +2479,15 @@ msgstr "Runden und geschlossene Runden"
 msgid "Labs"
 msgstr "Labore"
 
-#: hypha/apply/funds/admin_helpers.py:90 hypha/apply/funds/tables.py:563
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:16
-#: hypha/apply/funds/templates/funds/includes/round-block.html:16
+#: hypha/apply/funds/admin_helpers.py:90 hypha/apply/funds/tables.py:479
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:22
+#: hypha/apply/funds/templates/funds/includes/round-block.html:12
 #: hypha/apply/funds/templates/submissions/submenu/rounds.html:32
 msgid "Open"
 msgstr "Öffnen"
 
 #: hypha/apply/funds/admin_helpers.py:91
-#: hypha/apply/funds/templates/funds/includes/round-block.html:23
+#: hypha/apply/funds/templates/funds/includes/round-block.html:30
 #: hypha/apply/funds/templates/submissions/submenu/rounds.html:39
 msgid "Closed"
 msgstr "Geschlossen"
@@ -2508,91 +2502,96 @@ msgstr "Seite '{0}' und {1} Unterseiten kopiert."
 msgid "Page '{0}' copied."
 msgstr "Seite '{0}' kopiert."
 
-#: hypha/apply/funds/blocks.py:31
+#: hypha/apply/funds/blocks.py:32
 msgid "What is the title of your application?"
 msgstr "Was ist der Titel Ihrer Bewerbung?"
 
-#: hypha/apply/funds/blocks.py:36
+#: hypha/apply/funds/blocks.py:37
 msgid "This project name can be changed if a full proposal is requested."
 msgstr ""
 "Der Projektname kann geändert werden, wenn eine vollständiges Konzept "
 "angefordert wird."
 
-#: hypha/apply/funds/blocks.py:40
+#: hypha/apply/funds/blocks.py:39
+msgid "Max length"
+msgstr "Maximale Länge"
+
+#: hypha/apply/funds/blocks.py:42
 msgid "Application title"
 msgstr "Titel der Anwendung"
 
-#: hypha/apply/funds/blocks.py:51
+#: hypha/apply/funds/blocks.py:58
 msgid "Requested amount"
 msgstr "Angeforderter Betrag"
 
-#: hypha/apply/funds/blocks.py:66
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:56
+#: hypha/apply/funds/blocks.py:73
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:71
 msgid "Organization name"
 msgstr "Name der Organisation"
 
-#: hypha/apply/funds/blocks.py:73
+#: hypha/apply/funds/blocks.py:80
 msgid "What email address should we use to contact you?"
 msgstr "Welche E-Mail-Adresse sollen wir verwenden, um Sie zu kontaktieren?"
 
-#: hypha/apply/funds/blocks.py:79
+#: hypha/apply/funds/blocks.py:86
 msgid ""
 "We will use this email address to communicate with you about your proposal."
 msgstr ""
 "Wir werden diese E-Mail-Adresse verwenden, um uns mit Ihnen über Ihr "
 "Einreichung auszutauschen."
 
-#: hypha/apply/funds/blocks.py:97
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:49
-#: hypha/apply/funds/templates/funds/revisions_compare.html:40
+#: hypha/apply/funds/blocks.py:104
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:64
+#: hypha/apply/funds/templates/funds/revisions_compare.html:57
+#: hypha/apply/funds/templates/funds/revisions_compare.html:58
 msgid "Address"
 msgstr "Adresse"
 
-#: hypha/apply/funds/blocks.py:119
+#: hypha/apply/funds/blocks.py:126
 msgid "What is your name?"
 msgstr "Wie heißen Sie?"
 
-#: hypha/apply/funds/blocks.py:124
+#: hypha/apply/funds/blocks.py:131
 msgid "We will use this name when we communicate with you about your proposal."
 msgstr ""
 "Wir verwenden diesen Namen, wenn wir uns mit Ihnen über Ihre Einreichung "
 "unterhalten."
 
-#: hypha/apply/funds/blocks.py:129 hypha/apply/users/models.py:191
+#: hypha/apply/funds/blocks.py:142 hypha/apply/users/models.py:191
 msgid "Full name"
 msgstr "Vollständiger Name"
 
-#: hypha/apply/funds/blocks.py:214 hypha/apply/stream_forms/blocks.py:472
-#: hypha/apply/stream_forms/blocks.py:473
-#: hypha/apply/stream_forms/blocks.py:488
-#: hypha/apply/stream_forms/blocks.py:489 hypha/apply/utils/blocks.py:85
+#: hypha/apply/funds/blocks.py:228 hypha/apply/stream_forms/blocks.py:473
+#: hypha/apply/stream_forms/blocks.py:474
+#: hypha/apply/stream_forms/blocks.py:489
+#: hypha/apply/stream_forms/blocks.py:490 hypha/apply/utils/blocks.py:85
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: hypha/apply/funds/forms.py:61
+#: hypha/apply/funds/forms.py:64
 msgid "Take action"
 msgstr "Maßnahme ergreifen"
 
-#: hypha/apply/funds/forms.py:86 hypha/apply/projects/forms/project.py:427
+#: hypha/apply/funds/forms.py:89 hypha/apply/projects/forms/project.py:448
 #, python-brace-format
 msgid "Update lead from {lead} to"
 msgstr "Aktualisieren Sie den Vorgang von {lead} auf"
 
-#: hypha/apply/funds/forms.py:96 hypha/apply/funds/forms.py:241
+#: hypha/apply/funds/forms.py:99 hypha/apply/funds/forms.py:244
 msgid "External Reviewers"
 msgstr "Externe Reviewer"
 
-#: hypha/apply/funds/forms.py:175
+#: hypha/apply/funds/forms.py:178
 msgid "Can't unassign, just change, because review already submitted"
 msgstr ""
 "Kann nicht abbestellen, nur ändern, da die Bewertung bereits eingereicht "
 "wurde"
 
-#: hypha/apply/funds/forms.py:181 hypha/apply/funds/forms.py:293
+#: hypha/apply/funds/forms.py:184 hypha/apply/funds/forms.py:296
 msgid "Users cannot be assigned to multiple roles."
 msgstr "Benutzer können nicht mehreren Rollen zugewiesen werden."
 
-#: hypha/apply/funds/forms.py:281
+#: hypha/apply/funds/forms.py:284
 msgid ""
 "Make sure all submissions support external reviewers and you are lead for "
 "all the selected submissions."
@@ -2600,40 +2599,51 @@ msgstr ""
 "Stellen Sie sicher, dass alle Einreichungen externe Reviewer unterstützen "
 "und Sie Lead aller ausgewählten Einreichungen sind."
 
-#: hypha/apply/funds/forms.py:313
+#: hypha/apply/funds/forms.py:316
 msgid "---"
 msgstr "---"
 
-#: hypha/apply/funds/forms.py:317
+#: hypha/apply/funds/forms.py:320
 #, python-brace-format
 msgid "{role_name} Reviewer"
 msgstr "{role_name} Reviewer"
 
-#: hypha/apply/funds/forms.py:413
+#: hypha/apply/funds/forms.py:416
 msgid "Tags are hierarchical in nature."
 msgstr "Tags sind hierarchisch."
 
-#: hypha/apply/funds/models/__init__.py:36 hypha/apply/funds/tables.py:91
-#: hypha/apply/projects/tables.py:105 hypha/apply/projects/tables.py:171
-#: hypha/apply/projects/tables.py:245
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:32
+#: hypha/apply/funds/forms.py:473 hypha/apply/funds/forms.py:506
+msgid "Project permissions"
+msgstr "Projektgenehmigungen"
+
+#: hypha/apply/funds/forms.py:475 hypha/apply/funds/forms.py:508
+msgid ""
+"Enable same access level to these sections. Example: View role + Contracting "
+"= read-only contracting access."
+msgstr ""
+"Aktiviere die gleiche Zugangsstufe für diese Bereiche. Beispiel: Ansehen der "
+"Rolle + Vertrag = Schreibzugriff auf Verträge."
+
+#: hypha/apply/funds/models/__init__.py:39 hypha/apply/funds/tables.py:76
+#: hypha/apply/projects/tables.py:185 hypha/apply/projects/tables.py:261
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:50
 msgid "Fund"
 msgstr "Programm"
 
-#: hypha/apply/funds/models/__init__.py:43
+#: hypha/apply/funds/models/__init__.py:46
 msgid "RFP"
 msgstr "Ausschreibung"
 
-#: hypha/apply/funds/models/__init__.py:60
+#: hypha/apply/funds/models/__init__.py:63
 msgid "Lab"
 msgstr "Labor"
 
-#: hypha/apply/funds/models/applications.py:108
-#: hypha/apply/funds/models/applications.py:604
+#: hypha/apply/funds/models/applications.py:139
+#: hypha/apply/funds/models/applications.py:635
 msgid "Link to the apply guide."
 msgstr "Link zum Bewerbungsleitfaden."
 
-#: hypha/apply/funds/models/applications.py:115
+#: hypha/apply/funds/models/applications.py:146
 msgid ""
 "The slack #channel for notifications. If left empty, notifications will go "
 "to the default channel."
@@ -2641,7 +2651,7 @@ msgstr ""
 "Der Slack-Kanal #channel für Benachrichtigungen. Wenn leer gelassen, werden "
 "Benachrichtigungen an den Standardkanal gesendet."
 
-#: hypha/apply/funds/models/applications.py:123
+#: hypha/apply/funds/models/applications.py:154
 msgid ""
 "Comma separated list of emails where a summary of all the activities related "
 "to this fund will be sent."
@@ -2649,33 +2659,33 @@ msgstr ""
 "Durch Komma getrennte Liste von E-Mail-Adressen, an die eine Zusammenfassung "
 "aller Aktivitäten in Bezug auf dieses Programm gesendet wird."
 
-#: hypha/apply/funds/models/applications.py:128
+#: hypha/apply/funds/models/applications.py:159
 msgid "Should the fund be listed on the front page."
 msgstr "Soll das Programm auf der Startseite aufgelistet werden."
 
-#: hypha/apply/funds/models/applications.py:132
+#: hypha/apply/funds/models/applications.py:163
 msgid "Should the deadline date be visible for users."
 msgstr "Soll das Fälligkeitsdatum für Benutzer sichtbar sein."
 
-#: hypha/apply/funds/models/applications.py:183
-#: hypha/apply/funds/models/applications.py:311
-#: hypha/apply/funds/models/applications.py:642
+#: hypha/apply/funds/models/applications.py:214
+#: hypha/apply/funds/models/applications.py:342
+#: hypha/apply/funds/models/applications.py:673
 msgid "Content"
 msgstr "Inhalt"
 
-#: hypha/apply/funds/models/applications.py:185
-#: hypha/apply/funds/models/applications.py:312
-#: hypha/apply/funds/models/applications.py:644
+#: hypha/apply/funds/models/applications.py:216
+#: hypha/apply/funds/models/applications.py:343
+#: hypha/apply/funds/models/applications.py:675
 msgid "Promote"
 msgstr "Befördern"
 
-#: hypha/apply/funds/models/applications.py:217
-#: hypha/apply/funds/models/applications.py:572
+#: hypha/apply/funds/models/applications.py:248
+#: hypha/apply/funds/models/applications.py:603
 msgid "Submission ID Prefix"
 msgstr "Präfix der Einreichungs-ID"
 
-#: hypha/apply/funds/models/applications.py:223
-#: hypha/apply/funds/models/applications.py:578
+#: hypha/apply/funds/models/applications.py:254
+#: hypha/apply/funds/models/applications.py:609
 msgid ""
 "Prefix for the submission id. e.g. \"HYPHA23-\" will result in a submission "
 "id of \"HYPHA23-1\"."
@@ -2683,49 +2693,49 @@ msgstr ""
 "Präfix für die Einreichungs-ID. z. B. \"HYPHA23-\" ergibt eine Einreichungs-"
 "ID von \"HYPHA23-1\"."
 
-#: hypha/apply/funds/models/applications.py:245
+#: hypha/apply/funds/models/applications.py:276
 msgid "When no end date is provided the round will remain open indefinitely."
 msgstr "Wenn kein Enddatum angegeben wird, bleibt die Runde unbestimmt offen."
 
-#: hypha/apply/funds/models/applications.py:273
+#: hypha/apply/funds/models/applications.py:304
 msgid "Dates"
 msgstr "Daten"
 
-#: hypha/apply/funds/models/applications.py:279
-#: hypha/apply/funds/models/utils.py:62
+#: hypha/apply/funds/models/applications.py:310
+#: hypha/apply/funds/models/utils.py:63
 msgid "Workflow"
 msgstr "Arbeitsablauf"
 
-#: hypha/apply/funds/models/applications.py:280
-#: hypha/apply/funds/models/applications.py:287
-#: hypha/apply/funds/models/applications.py:293
-#: hypha/apply/funds/models/applications.py:298
-#: hypha/apply/funds/models/applications.py:304
+#: hypha/apply/funds/models/applications.py:311
+#: hypha/apply/funds/models/applications.py:318
+#: hypha/apply/funds/models/applications.py:324
+#: hypha/apply/funds/models/applications.py:329
+#: hypha/apply/funds/models/applications.py:335
 msgid "Copied from the fund."
 msgstr "Kopiert aus dem Programm."
 
-#: hypha/apply/funds/models/applications.py:286
-#: hypha/apply/funds/models/utils.py:147
+#: hypha/apply/funds/models/applications.py:317
+#: hypha/apply/funds/models/utils.py:148
 msgid "Application forms"
 msgstr "Bewerbungsformulare"
 
-#: hypha/apply/funds/models/applications.py:292
+#: hypha/apply/funds/models/applications.py:323
 msgid "Internal Review Form"
 msgstr "Internes Bewertungsformular"
 
-#: hypha/apply/funds/models/applications.py:299
+#: hypha/apply/funds/models/applications.py:330
 msgid "External Review Form"
 msgstr "Externe Bewertungsformular"
 
-#: hypha/apply/funds/models/applications.py:305
+#: hypha/apply/funds/models/applications.py:336
 msgid "Determination Form"
 msgstr "Entscheidungsformular"
 
-#: hypha/apply/funds/models/applications.py:608
+#: hypha/apply/funds/models/applications.py:639
 msgid "The slack #channel for notifications."
 msgstr "Der Slack-Kanal #channel für Benachrichtigungen."
 
-#: hypha/apply/funds/models/applications.py:616
+#: hypha/apply/funds/models/applications.py:647
 msgid ""
 "Comma separated list of emails where a summary of all the activities related "
 "to this lab will be sent."
@@ -2733,9 +2743,54 @@ msgstr ""
 "Durch Komma getrennte Liste von E-Mail-Adressen, an die eine Zusammenfassung "
 "aller Aktivitäten in diesem Labor gesendet wird."
 
-#: hypha/apply/funds/models/applications.py:621
+#: hypha/apply/funds/models/applications.py:652
 msgid "Should the lab be listed on the front page."
 msgstr "Soll das Labor auf der Startseite aufgelistet werden."
+
+#: hypha/apply/funds/models/co_applicants.py:14
+msgid "Project Document"
+msgstr "Projektdokument"
+
+#: hypha/apply/funds/models/co_applicants.py:15
+msgid "Contracting Document"
+msgstr "Vertragsdokument"
+
+#: hypha/apply/funds/models/co_applicants.py:17
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:10
+#: hypha/apply/projects/reports/templates/reports/report_list.html:6
+#: hypha/core/navigation.py:114
+msgid "Reports"
+msgstr "Berichte"
+
+#: hypha/apply/funds/models/co_applicants.py:21
+#: hypha/apply/funds/templates/funds/submissions_result.html:63
+#: hypha/apply/projects/templates/application_projects/paf_export.html:22
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:22
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:53
+msgid "Pending"
+msgstr "Ausstehend"
+
+#: hypha/apply/funds/models/co_applicants.py:22
+#: hypha/apply/funds/templates/funds/submissions_result.html:31
+#: hypha/apply/funds/templates/funds/submissions_result.html:55
+#: hypha/apply/funds/workflows/constants.py:91
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:191
+#: hypha/apply/funds/workflows/definitions/double_stage.py:311
+#: hypha/apply/funds/workflows/definitions/single_stage.py:134
+#: hypha/apply/funds/workflows/definitions/single_stage_community.py:197
+#: hypha/apply/funds/workflows/definitions/single_stage_external.py:170
+#: hypha/apply/funds/workflows/definitions/single_stage_same.py:123
+msgid "Accepted"
+msgstr "Akzeptiert"
+
+#: hypha/apply/funds/models/co_applicants.py:23
+msgid "Rejected"
+msgstr "Zurückgewiesen"
+
+#: hypha/apply/funds/models/co_applicants.py:24
+#: hypha/apply/funds/templates/funds/includes/reminders_block.html:14
+msgid "Expired"
+msgstr "Abgelaufen"
 
 #: hypha/apply/funds/models/reviewer_role.py:19
 msgid "The order this role should appear in the Update Reviewers form."
@@ -2782,37 +2837,54 @@ msgstr ""
 "Nur eine Ja- und Nein-Überprüfung zur Bewertung kann als Standard festgelegt "
 "werden."
 
-#: hypha/apply/funds/models/submissions.py:481
+#: hypha/apply/funds/models/submissions.py:514
 msgid "submit time"
 msgstr "Einreichungszeit"
 
-#: hypha/apply/funds/models/utils.py:148
+#: hypha/apply/funds/models/utils.py:149
 msgid "Internal Review Forms"
 msgstr "Interne Bewertungsformulare"
 
-#: hypha/apply/funds/models/utils.py:151
+#: hypha/apply/funds/models/utils.py:152
 msgid "External Review Forms"
 msgstr "Externe Bewertungsformulare"
 
-#: hypha/apply/funds/models/utils.py:155
+#: hypha/apply/funds/models/utils.py:156
 msgid "Determination Forms"
 msgstr "Entscheidungsformulare"
 
 #: hypha/apply/funds/models/utils.py:161
+#: hypha/apply/projects/templates/application_projects/paf_export.html:5
+msgid "Project Form"
+msgstr "Projektformular"
+
+#: hypha/apply/funds/models/utils.py:162
 msgid "Project SOW Form"
 msgstr "Projekt-Statement-of-Work-Formular"
 
-#: hypha/apply/funds/models/utils.py:163
+#: hypha/apply/funds/models/utils.py:164
 msgid "Project Report Form"
 msgstr "Projektberichtsformular"
 
-#: hypha/apply/funds/models/utils.py:179
+#: hypha/apply/funds/models/utils.py:180
 msgid "Additional text for the application confirmation message."
 msgstr "Zusätzlicher Text für die Bestätigungsnachricht der Bewerbung."
 
-#: hypha/apply/funds/models/utils.py:198 hypha/apply/funds/models/utils.py:202
+#: hypha/apply/funds/models/utils.py:199 hypha/apply/funds/models/utils.py:203
 msgid "Confirmation email"
 msgstr "Bestätigungs-E-Mail"
+
+#: hypha/apply/funds/models/utils.py:213
+msgid "Failed"
+msgstr "Misslungen"
+
+#: hypha/apply/funds/models/utils.py:214
+msgid "Success"
+msgstr "Erfolg"
+
+#: hypha/apply/funds/models/utils.py:215
+msgid "In Progress"
+msgstr "Im Gange"
 
 #: hypha/apply/funds/services.py:44
 #, python-brace-format
@@ -2839,87 +2911,103 @@ msgstr "{user} als {name}"
 msgid "Batch reviewers updated: {reviewers_text} on "
 msgstr "Batch reviewers updated: {reviewers_text} on "
 
-#: hypha/apply/funds/tables.py:86
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:21
-#: hypha/apply/projects/filters.py:35 hypha/apply/projects/filters.py:58
-#: hypha/apply/projects/filters.py:99 hypha/apply/projects/forms/payment.py:208
-#: hypha/apply/projects/tables.py:169 hypha/apply/projects/tables.py:243
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:24
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:56
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:22
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:4
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:9
+#: hypha/apply/funds/tables.py:71 hypha/apply/projects/filters.py:39
+#: hypha/apply/projects/filters.py:57 hypha/apply/projects/forms/payment.py:208
+#: hypha/apply/projects/reports/filters.py:28
+#: hypha/apply/projects/tables.py:183 hypha/apply/projects/tables.py:259
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:27
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:58
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:6
 #: hypha/apply/users/templates/wagtailusers/users/list.html:29
 msgid "Status"
 msgstr "Status"
 
-#: hypha/apply/funds/tables.py:90
+#: hypha/apply/funds/tables.py:75
 msgid "Type"
 msgstr "Typ"
 
-#: hypha/apply/funds/tables.py:94
-#: hypha/apply/funds/templates/funds/tables/table.html:22
-#: hypha/apply/review/templates/review/review_detail.html:20
+#: hypha/apply/funds/tables.py:77
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:41
+#: hypha/apply/funds/templates/funds/comments.html:37
+#: hypha/apply/projects/templates/application_projects/project_detail.html:31
+msgid "Comments"
+msgstr "Kommentare"
+
+#: hypha/apply/funds/tables.py:79
+#: hypha/apply/review/templates/review/review_detail.html:11
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
-#: hypha/apply/funds/tables.py:117
+#: hypha/apply/funds/tables.py:101
 msgid "No submissions available"
 msgstr "Keine Einreichungen verfügbar"
 
-#: hypha/apply/funds/tables.py:174 hypha/apply/funds/tables.py:344
+#: hypha/apply/funds/tables.py:158 hypha/apply/funds/tables.py:275
 msgid "Screening"
 msgstr "Überprüfung"
 
-#: hypha/apply/funds/tables.py:218
-msgid "Role"
-msgstr "Rolle"
-
-#: hypha/apply/funds/tables.py:326
+#: hypha/apply/funds/tables.py:257
 msgid "Statuses"
 msgstr "Status"
 
-#: hypha/apply/funds/tables.py:339 hypha/apply/funds/tables.py:454
-#: hypha/apply/funds/tables.py:560 hypha/apply/funds/tables.py:597
-#: hypha/apply/projects/filters.py:31 hypha/apply/projects/filters.py:52
+#: hypha/apply/funds/tables.py:270 hypha/apply/funds/tables.py:361
+#: hypha/apply/funds/tables.py:476 hypha/apply/funds/tables.py:513
+#: hypha/apply/projects/filters.py:35 hypha/apply/projects/filters.py:51
 msgid "Funds"
 msgstr "Programme"
 
-#: hypha/apply/funds/tables.py:341 hypha/apply/funds/tables.py:452
-#: hypha/apply/funds/tables.py:602
+#: hypha/apply/funds/tables.py:272 hypha/apply/funds/tables.py:359
+#: hypha/apply/funds/tables.py:518
 #: hypha/apply/funds/templates/funds/rounds.html:5
-#: hypha/apply/funds/templates/funds/rounds.html:9
+#: hypha/apply/funds/templates/funds/rounds.html:10
 msgid "Rounds"
 msgstr "Runden"
 
-#: hypha/apply/funds/tables.py:342 hypha/apply/funds/tables.py:561
+#: hypha/apply/funds/tables.py:273 hypha/apply/funds/tables.py:477
 msgid "Leads"
 msgstr "Leads"
 
-#: hypha/apply/funds/tables.py:344
+#: hypha/apply/funds/tables.py:275
 msgid "No Status"
 msgstr "Kein Status"
 
-#: hypha/apply/funds/tables.py:350
+#: hypha/apply/funds/tables.py:281
 #: hypha/apply/projects/templates/application_projects/modals/contracting_documents_upload.html:7
 #: hypha/apply/projects/templates/application_projects/modals/supporting_documents_upload.html:7
 msgid "Category"
 msgstr "Kategorie"
 
-#: hypha/apply/funds/tables.py:482
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:23
+#: hypha/apply/funds/tables.py:392
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:46
 msgid "Determined"
 msgstr "Bestimmt"
 
-#: hypha/apply/funds/tables.py:636 hypha/apply/funds/tables.py:670
+#: hypha/apply/funds/tables.py:393
+msgid "Start"
+msgstr "Anfangen"
+
+#: hypha/apply/funds/tables.py:394
+msgid "End"
+msgstr "Ende"
+
+#: hypha/apply/funds/tables.py:478
+#: hypha/apply/users/templates/wagtailusers/users/list.html:58
+msgid "Active"
+msgstr "Aktiv"
+
+#: hypha/apply/funds/tables.py:555 hypha/apply/funds/tables.py:589
 msgid "No reviews available"
 msgstr "Keine Bewertungen verfügbar"
 
-#: hypha/apply/funds/tables.py:677 hypha/apply/users/roles.py:6
+#: hypha/apply/funds/tables.py:564
+msgid "Submission"
+msgstr "Einreichung"
+
+#: hypha/apply/funds/tables.py:596 hypha/apply/users/roles.py:6
 msgid "Staff"
 msgstr "Team"
 
-#: hypha/apply/funds/tables.py:687
+#: hypha/apply/funds/tables.py:606
 msgid "No staff available"
 msgstr "Kein Teammitglied verfügbar"
 
@@ -2940,53 +3028,55 @@ msgstr ""
 msgid "Continue"
 msgstr "Fortsetzen"
 
-#: hypha/apply/funds/templates/funds/application_base.html:13
-#: hypha/home/templates/home/includes/fund-list-item.html:13
+#: hypha/apply/funds/templates/funds/application_base.html:11
+#: hypha/home/templates/home/includes/fund-list-item.html:17
 msgid "Next deadline"
 msgstr "Nächste Frist"
 
-#: hypha/apply/funds/templates/funds/application_base.html:27
+#: hypha/apply/funds/templates/funds/application_base.html:28
 msgid ""
-"There were some errors with your form. Please amend the fields highlighted "
-"below"
+"Please fix the errors in your form. Review and update the highlighted fields "
+"below to continue."
 msgstr ""
-"Es gab einige Fehler in Ihrem Formular. Bitte korrigieren Sie die unten "
-"hervorgehobenen Felder"
-
-#: hypha/apply/funds/templates/funds/application_base.html:34
-#, python-format
-msgid ""
-"Sorry this %(page|verbose_name)s is not accepting applications at the moment"
-msgstr ""
-"Entschuldigung, diese %(page|verbose_name)s nimmt derzeit keine Anträge an"
+"Bitte korrigieren Sie die Fehler in Ihrem Formular. Überprüfen und "
+"aktualisieren Sie die unten markierten Felder, um fortzufahren."
 
 #: hypha/apply/funds/templates/funds/application_base.html:38
+#, python-format
+msgid "Sorry, this %(name)s is not currently accepting applications."
+msgstr "Entschuldigung, dieser %(name)s nimmt derzeit keine Bewerbungen an."
+
+#: hypha/apply/funds/templates/funds/application_base.html:40
+msgid "See other funds"
+msgstr "Siehe andere Fonds"
+
+#: hypha/apply/funds/templates/funds/application_base.html:51
 msgid "Application guide"
 msgstr "Bewerbungsleitfaden"
 
-#: hypha/apply/funds/templates/funds/application_base.html:71
-#: hypha/apply/funds/views/submission_edit.py:129
+#: hypha/apply/funds/templates/funds/application_base.html:98
+#: hypha/apply/funds/views/submission_edit.py:122
 msgid "Preview and submit"
 msgstr "Vorschau und senden"
 
-#: hypha/apply/funds/templates/funds/application_base.html:73
-#: hypha/apply/funds/templates/funds/application_preview.html:46
+#: hypha/apply/funds/templates/funds/application_base.html:106
+#: hypha/apply/funds/templates/funds/application_preview.html:59
 msgid "Submit for review"
 msgstr "Zur Bewertung einreichen"
 
-#: hypha/apply/funds/templates/funds/application_base.html:77
-#: hypha/apply/funds/views/submission_edit.py:134
-#: hypha/apply/funds/views/submission_edit.py:319
+#: hypha/apply/funds/templates/funds/application_base.html:127
+#: hypha/apply/funds/views/submission_edit.py:127
+#: hypha/apply/funds/views/submission_edit.py:306
 msgid "Preview"
 msgstr "Vorschau"
 
-#: hypha/apply/funds/templates/funds/application_base.html:81
-#: hypha/apply/funds/templates/funds/applicationsubmission_form.html:41
+#: hypha/apply/funds/templates/funds/application_base.html:133
+#: hypha/apply/funds/templates/funds/applicationsubmission_form.html:58
 msgid "You must have Javascript enabled to use this form."
 msgstr "Sie müssen Javascript aktivieren, um dieses Formular zu verwenden."
 
 #: hypha/apply/funds/templates/funds/application_preview.html:3
-#: hypha/apply/funds/templates/funds/application_preview.html:9
+#: hypha/apply/funds/templates/funds/application_preview.html:7
 msgid "Previewing"
 msgstr "Vorschau"
 
@@ -2995,144 +3085,236 @@ msgstr "Vorschau"
 msgid "Revisions for %(title)s"
 msgstr "Revisionen für %(title)s"
 
-#: hypha/apply/funds/templates/funds/applicationrevision_list.html:7
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:85
-msgid "Revisions"
-msgstr "Revisionen"
+#: hypha/apply/funds/templates/funds/applicationrevision_list.html:8
+#, python-format
+msgid "Edits to %(title)s"
+msgstr "Bearbeitungen an %(title)s"
 
-#: hypha/apply/funds/templates/funds/applicationrevision_list.html:19
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:5
-msgid "current"
-msgstr "aktuell"
+#: hypha/apply/funds/templates/funds/applicationrevision_list.html:25
+#: hypha/apply/funds/templates/funds/revisions_compare.html:94
+#: hypha/apply/funds/templates/funds/revisions_compare.html:119
+msgid "edited"
+msgstr "bearbeitete"
 
-#: hypha/apply/funds/templates/funds/applicationrevision_list.html:26
-#: hypha/apply/funds/templates/funds/revisions_compare.html:3
-#: hypha/apply/review/templates/review/review_detail.html:70
-msgid "Compare"
-msgstr "Vergleichen"
+#: hypha/apply/funds/templates/funds/applicationrevision_list.html:40
+#: hypha/apply/funds/templates/funds/revisions_compare.html:109
+msgid "latest"
+msgstr "neueste"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:12
-#: hypha/apply/funds/templates/funds/applicationsubmission_reviewer_detail.html:6
+#: hypha/apply/funds/templates/funds/applicationrevision_list.html:47
+msgid "Compare with latest"
+msgstr "Vergleich mit dem neuesten"
+
+#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:18
+#: hypha/apply/funds/templates/funds/applicationsubmission_reviewer_detail.html:7
 msgid "Flags"
 msgstr "Kennzeichnungen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:20
-#: hypha/apply/funds/templates/funds/applicationsubmission_community_detail.html:6
-#: hypha/apply/funds/templates/funds/applicationsubmission_reviewer_detail.html:13
+#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:27
+#: hypha/apply/funds/templates/funds/applicationsubmission_community_detail.html:7
+#: hypha/apply/funds/templates/funds/applicationsubmission_reviewer_detail.html:16
 msgid "Reviews & assignees"
 msgstr "Bewertungen und Zuweisungen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:34
+#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:50
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:66
 msgid "View all"
 msgstr "Alle anzeigen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:66
+#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:87
 msgid "Reminders"
 msgstr "Erinnerungen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:72
-#: hypha/apply/funds/templates/funds/modals/create_reminder_form.html:2
-msgid "Create reminder"
-msgstr "Erinnerung erstellen"
+#: hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html:93
+msgid "Create new reminder"
+msgstr "Neue Erinnerung erstellen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:25
-#: hypha/apply/funds/templates/funds/comments.html:21
+#: hypha/apply/funds/templates/funds/applicationsubmission_confirm_delete.html:3
+msgid "Delete application"
+msgstr "Anwendung löschen"
+
+#: hypha/apply/funds/templates/funds/applicationsubmission_confirm_delete.html:5
+msgid ""
+"Are you sure you want to delete this application? All of your data for this "
+"application will be permanently removed from our servers forever. This "
+"action cannot be undone."
+msgstr ""
+"Bist du sicher, dass du diese Anwendung löschen willst? Alle Ihre Daten für "
+"diese Anwendung werden dauerhaft von unseren Servern entfernt. Diese "
+"Maßnahme kann nicht rückgängig gemacht werden."
+
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:22
+#: hypha/apply/funds/templates/funds/comments.html:18
 #: hypha/apply/projects/templates/application_projects/paf_export.html:76
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:85
-#: hypha/apply/projects/templates/application_projects/project_detail.html:22
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:107
+#: hypha/apply/projects/templates/application_projects/project_detail.html:17
 msgid "Application"
 msgstr "Anwendung"
 
 #: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:32
 #: hypha/apply/funds/templates/funds/comments.html:28
-#: hypha/apply/projects/templates/application_projects/project_detail.html:29
-msgid "Conversations"
-msgstr "Diskussion"
+#: hypha/apply/funds/templates/funds/includes/submission-list-row.html:128
+#: hypha/apply/funds/templates/funds/includes/submission-table-row.html:53
+#: hypha/apply/projects/templates/application_projects/project_detail.html:24
+msgid "Project"
+msgstr "Projekt"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:46
-#: hypha/apply/funds/templates/funds/comments.html:45
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:50
+#: hypha/apply/funds/templates/funds/comments.html:46
 msgid "View message log"
 msgstr "Nachrichtenprotokoll anzeigen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:58
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:61
 msgid "Congratulations!"
 msgstr "Herzlichen Glückwunsch!"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:59
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:62
 #, python-format
 msgid "Your %(stage)s application has been accepted."
 msgstr "Ihre %(stage)s-Bewerbung wurde angenommen."
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:67
-msgid "This application has been archived. This is visible to the roles "
-msgstr ""
-"Diese Einreichung wurde archiviert. Dies ist für die Rollen {role} sichtbar "
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:71
+msgid "This application has been archived. This is visible to accounts with "
+msgstr "Dieser Antrag wurde archiviert. Dies ist für Konten mit sichtbar "
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:74
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:79
 msgid "This application is sealed."
 msgstr "Diese Einreichung ist gesperrt."
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:81
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:86
 msgid "Drafted "
 msgstr "Entworfen "
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:83
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:86
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:22
 msgid "Submitted "
 msgstr "Eingereicht "
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:91
-#: hypha/apply/funds/templates/submissions/all.html:370
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:94
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:34
 msgid "Updated"
 msgstr "Aktualisiert"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:106
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:123
 msgid "Delete Submission"
 msgstr "Einreichung löschen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:165
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:189
 msgid "Related submissions"
 msgstr "Zugehörige Informationen"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:168
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:172
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:197
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:208
 msgid "View linked"
 msgstr "View linked"
 
-#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:179
+#: hypha/apply/funds/templates/funds/applicationsubmission_detail.html:217
 msgid "Other Submissions"
 msgstr "Andere Einreichungen"
 
 #: hypha/apply/funds/templates/funds/applicationsubmission_form.html:3
-#: hypha/apply/funds/templates/funds/applicationsubmission_form.html:8
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:15
+#: hypha/apply/funds/templates/funds/applicationsubmission_form.html:9
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:14
 #: hypha/apply/projects/templates/application_projects/project_approval_form.html:3
-#: hypha/apply/projects/templates/application_projects/project_approval_form.html:12
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:10
 #: hypha/apply/projects/templates/application_projects/project_form.html:5
-#: hypha/apply/projects/templates/application_projects/project_form.html:10
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:3
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:12
+#: hypha/apply/projects/templates/application_projects/project_form.html:9
 #: hypha/apply/users/templates/wagtailusers/users/edit.html:9
 msgid "Editing"
 msgstr "Bearbeiten"
 
-#: hypha/apply/funds/templates/funds/comments.html:56
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:9
+msgid "Accept invitation"
+msgstr "Einladung annehmen"
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:12
+#, python-format
+msgid ""
+"\n"
+"                        You have been invited to join the application "
+"\"%(title)s\" as a co-applicant.\n"
+"                    "
+msgstr ""
+"\n"
+"Sie wurden eingeladen, als Mitbewerber an der Bewerbung \"%(title)s\" "
+"teilzunehmen.\n"
+"                    "
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:18
+#, python-format
+msgid ""
+"If you accept this invitation, an account will be created using the email "
+"<strong>%(email)s</strong> and you will be redirected to"
+msgstr ""
+"Wenn du diese Einladung annimmst, wird ein Konto mit der E-Mail "
+"<strong>%(email)s</strong> erstellt und du wirst weitergeleitet zu"
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:19
+msgid "two-factor authentication and then to"
+msgstr "Zwei-Faktor-Authentifizierung und dann zu"
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:19
+msgid ""
+"the application. If you wish to update your name/email, you can do it by "
+"visiting 'My Account' section."
+msgstr ""
+"Die Anwendung. Wenn Sie Ihren Namen/Ihre E-Mail-Adresse aktualisieren "
+"möchten, können Sie dies tun, indem Sie den Bereich 'Mein Konto' besuchen."
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:30
+msgid "Decline"
+msgstr "Ablehnen"
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:38
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:181
+#: hypha/apply/funds/workflows/definitions/double_stage.py:270
+#: hypha/apply/funds/workflows/definitions/double_stage.py:301
+#: hypha/apply/funds/workflows/definitions/double_stage.py:318
+#: hypha/apply/funds/workflows/definitions/single_stage.py:37
+#: hypha/apply/funds/workflows/definitions/single_stage.py:60
+#: hypha/apply/funds/workflows/definitions/single_stage.py:89
+#: hypha/apply/funds/workflows/definitions/single_stage.py:111
+#: hypha/apply/funds/workflows/definitions/single_stage.py:124
+#: hypha/apply/funds/workflows/definitions/single_stage.py:141
+#: hypha/apply/funds/workflows/definitions/single_stage_community.py:154
+#: hypha/apply/funds/workflows/definitions/single_stage_community.py:187
+#: hypha/apply/funds/workflows/definitions/single_stage_community.py:204
+#: hypha/apply/funds/workflows/definitions/single_stage_external.py:127
+#: hypha/apply/funds/workflows/definitions/single_stage_external.py:160
+#: hypha/apply/funds/workflows/definitions/single_stage_external.py:177
+#: hypha/apply/funds/workflows/definitions/single_stage_same.py:113
+#: hypha/apply/funds/workflows/definitions/single_stage_same.py:130
+msgid "Accept"
+msgstr "Akzeptieren"
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:41
+msgid "Invalid Invitation"
+msgstr "Ungültige Einladung"
+
+#: hypha/apply/funds/templates/funds/coapplicant_invite_landing_page.html:43
+msgid ""
+"This invitation link is no longer valid or has expired. Please request a new "
+"invitation to proceed."
+msgstr ""
+"Dieser Einladungslink ist nicht mehr gültig oder abgelaufen. Bitte fordern "
+"Sie eine neue Einladung an, um fortzufahren."
+
+#: hypha/apply/funds/templates/funds/comments.html:57
 msgid "Add communication"
 msgstr "Kommunikation hinzufügen"
 
-#: hypha/apply/funds/templates/funds/comments.html:79
+#: hypha/apply/funds/templates/funds/comments.html:80
+#: hypha/apply/funds/templates/funds/comments.html:94
 msgid "Add Comment"
 msgstr "Kommentar hinzufügen"
 
-#: hypha/apply/funds/templates/funds/grouped_application_list.html:7
-msgid "List of Submissions summary"
-msgstr "List of Submissions summary"
-
 #: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:4
-#: hypha/apply/funds/templates/funds/includes/generic_primary_actions.html:5
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:3
-#: hypha/apply/projects/templates/application_projects/project_admin_detail.html:11
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:96
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:40
+#: hypha/apply/funds/templates/funds/includes/generic_primary_actions.html:6
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:88
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:4
+#: hypha/apply/projects/templates/application_projects/project_admin_detail.html:10
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:128
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:35
 msgid "Actions to take"
 msgstr "Nächste Aktion"
 
@@ -3141,78 +3323,114 @@ msgstr "Nächste Aktion"
 msgid "Unarchive Submission"
 msgstr "Einreichung nicht mehr archivieren"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:21
-msgid "Create Project"
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:26
+#: hypha/apply/funds/templates/funds/modals/create_project_form.html:2
+msgid "Create project"
 msgstr "Projekt erstellen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:27
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:32
 msgid "Complete draft determination"
 msgstr "Entscheidung zum Entwurf abschließen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:32
-#: hypha/apply/funds/templates/funds/includes/generic_primary_actions.html:8
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:37
+#: hypha/apply/funds/templates/funds/includes/generic_primary_actions.html:9
 msgid "Complete draft review"
 msgstr "Bewertung des Entwurfs abschließen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:40
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:45
 msgid "Assign reviewers"
 msgstr "Zuweisung von Reviewer"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:47
-#: hypha/apply/funds/templates/funds/includes/generic_primary_actions.html:18
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:55
+#: hypha/apply/funds/templates/funds/includes/generic_primary_actions.html:19
 msgid "View determination"
 msgstr "Entscheidungen ansehen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:58
-#: hypha/apply/projects/templates/application_projects/modals/batch_invoice_status_update.html:20
-#: hypha/apply/projects/views/payment.py:119
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:68
+#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:27
+#: hypha/apply/projects/templates/application_projects/modals/batch_invoice_status_update.html:34
+#: hypha/apply/projects/views/payment.py:137
 msgid "Update status"
 msgstr "Status aktualisieren"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:61
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:73
 msgid "Assign"
 msgstr "Zuweisen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:80
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:93
 #: hypha/apply/funds/templates/funds/submission_sealed.html:14
-#: hypha/apply/funds/templates/submissions/partials/submission-lead.html:8
-#: hypha/apply/funds/templates/submissions/partials/submission-lead.html:12
-#: hypha/apply/projects/filters.py:37 hypha/apply/projects/filters.py:55
-#: hypha/apply/projects/tables.py:106
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:30
-#: hypha/apply/projects/templates/application_projects/partials/project-lead.html:9
-#: hypha/apply/projects/templates/application_projects/partials/project-lead.html:13
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:21
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:19
+#: hypha/apply/funds/templates/submissions/partials/submission-lead.html:10
+#: hypha/apply/funds/templates/submissions/partials/submission-lead.html:14
+#: hypha/apply/projects/filters.py:41 hypha/apply/projects/filters.py:54
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:46
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:10
 msgid "Lead"
 msgstr "Lead"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:84
-#: hypha/apply/projects/templates/application_projects/project_admin_detail.html:24
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:98
 msgid "More actions"
 msgstr "Weitere Aktionen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:90
-#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:2
-#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:73
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:107
+#: hypha/apply/funds/templates/funds/revisions_compare.html:88
+msgid "Revisions"
+msgstr "Revisionen"
+
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:117
+#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:69
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:104
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:136
 #: hypha/apply/funds/views/reminders.py:69
 msgid "Create Reminder"
 msgstr "Erinnerung erstellen"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:109
-msgid "Download PDF"
-msgstr "PDF herunterladen"
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:144
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:178
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:53
+msgid "Download as PDF"
+msgstr "Herunterladen als PDF"
 
-#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:115
-msgid "Archive Submission"
-msgstr "Archiv für Einreichungen"
+#: hypha/apply/funds/templates/funds/includes/admin_primary_actions.html:154
+#: hypha/apply/funds/templates/funds/includes/modal_archive_submission_confirm.html:27
+#: hypha/apply/funds/templates/submissions/all.html:488
+msgid "Archive"
+msgstr "Archiv"
+
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:8
+msgid "Co-applicants"
+msgstr "Mitbewerber"
+
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:18
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:19
+#: hypha/apply/funds/templates/funds/modals/invite_co_applicant_form.html:2
+msgid "Invite co-applicant"
+msgstr "Einladung des Mitbewerbers"
+
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:22
+msgid "Not allowed"
+msgstr "Unstatthaft"
+
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:25
+#: hypha/apply/funds/views/co_applicants.py:58
+#: hypha/apply/funds/views/co_applicants.py:102
+msgid "Invite"
+msgstr "Einladen"
+
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:33
+msgid ""
+"Project permissions are enabled and can be updated for each co-applicant."
+msgstr ""
+"Projektberechtigungen sind aktiviert und können für jeden Mitbewerber "
+"aktualisiert werden."
+
+#: hypha/apply/funds/templates/funds/includes/co-applicant-block.html:74
+msgid "No co-applicants yet."
+msgstr "Noch keine Mitbewerber."
 
 #: hypha/apply/funds/templates/funds/includes/delegated_form_base.html:29
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:100
+#: hypha/templates/cotton/modal/header.html:16
 msgid "Close"
 msgstr "Schließen"
 
@@ -3227,12 +3445,8 @@ msgstr ""
 "\n"
 "Sind Sie sicher, dass Sie die Einreichung archivieren möchten? Archivierte "
 "Einreichungen werden in der Hauptliste der Einreichungen ausgeblendet und "
-"können nicht bearbeitet werden."
-
-#: hypha/apply/funds/templates/funds/includes/modal_archive_submission_confirm.html:27
-#: hypha/apply/funds/templates/submissions/all.html:521
-msgid "Archive"
-msgstr "Archiv"
+"können nicht bearbeitet werden.\n"
+"                    "
 
 #: hypha/apply/funds/templates/funds/includes/modal_unarchive_submission_confirm.html:16
 msgid ""
@@ -3245,82 +3459,83 @@ msgstr ""
 "\n"
 "Sind Sie sicher, dass Sie diese Einreichung entsperren möchten? Diese "
 "Einreichung wird in der Hauptliste der Einreichungen sichtbar sein und kann "
-"bearbeitet werden."
+"bearbeitet werden.\n"
+"                    "
 
 #: hypha/apply/funds/templates/funds/includes/modal_unarchive_submission_confirm.html:29
 msgid "Unarchive"
 msgstr "Entarchivieren"
 
-#: hypha/apply/funds/templates/funds/includes/no_round_block_dashboard.html:6
+#: hypha/apply/funds/templates/funds/includes/no_round_block_dashboard.html:9
 #, python-format
 msgid "You have no %(type)s rounds or labs assigned to you."
 msgstr "Sie haben keine %(type)s-Runden oder -Labore zugewiesen."
 
-#: hypha/apply/funds/templates/funds/includes/reminders_block.html:14
-msgid "Expired"
-msgstr "Abgelaufen"
-
-#: hypha/apply/funds/templates/funds/includes/reminders_block.html:33
+#: hypha/apply/funds/templates/funds/includes/reminders_block.html:34
 msgid "No reminders yet."
 msgstr "Bisher keine Erinnerungen."
 
 #: hypha/apply/funds/templates/funds/includes/rendered_answers.html:8
 #, python-format
 msgid ""
-" This application is translated from %(from_lang_name)s to %(to_lang_name)s. "
+" This application is translated from %(from_lang_name)s to %(to_lang_name)s."
 msgstr ""
-" Diese Einreichung ist von %(from_lang_name)s nach %(to_lang_name)s "
-"übersetzt."
+" Diese Anwendung wird von %(from_lang_name)s in %(to_lang_name)s übersetzt."
 
 #: hypha/apply/funds/templates/funds/includes/rendered_answers.html:10
 msgid "See original"
 msgstr "Siehe Original"
 
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:21
-#: hypha/apply/funds/templates/submissions/partials/applicationsubmission.html:2
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:27
 msgid "Proposal Information"
 msgstr "Informationen zum Konzept"
 
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:25
-#: hypha/apply/funds/templates/funds/revisions_compare.html:44
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:33
+#: hypha/apply/funds/templates/funds/revisions_compare.html:67
+#: hypha/apply/funds/templates/funds/revisions_compare.html:68
 msgid "Requested Funding"
 msgstr "Angeforderte Finanzierung"
 
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:32
-#: hypha/apply/funds/templates/funds/revisions_compare.html:42
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:40
+#: hypha/apply/funds/templates/funds/revisions_compare.html:62
+#: hypha/apply/funds/templates/funds/revisions_compare.html:63
 msgid "Project Duration"
 msgstr "Projektlaufzeit"
 
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:40
-#: hypha/apply/funds/templates/funds/revisions_compare.html:36
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:48
+#: hypha/apply/funds/templates/funds/revisions_compare.html:47
+#: hypha/apply/funds/templates/funds/revisions_compare.html:48
 msgid "Legal Name"
 msgstr "Gesetzlicher Name"
 
-#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:44
-#: hypha/apply/funds/templates/funds/revisions_compare.html:38
-#: hypha/apply/projects/templates/application_projects/project_detail.html:65
+#: hypha/apply/funds/templates/funds/includes/rendered_answers.html:59
+#: hypha/apply/funds/templates/funds/revisions_compare.html:52
+#: hypha/apply/funds/templates/funds/revisions_compare.html:53
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:10
 msgid "E-mail"
 msgstr "E-Mail"
 
-#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:23
+#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:22
 msgid "No staff reviewers yet"
 msgstr "Noch keine Teammitglied-Reviewer"
 
-#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:26
+#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:24
 msgid "No public reviews yet"
 msgstr "Keine öffentlichen Bewertungen bisher"
 
-#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:52
+#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:45
 msgid "Show more..."
 msgstr "Mehr anzeigen..."
 
-#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:53
+#: hypha/apply/funds/templates/funds/includes/review_sidebar.html:46
 msgid "Show less..."
 msgstr "Zeige weniger..."
 
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:29
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:50
-#: hypha/apply/funds/templates/submissions/all.html:181
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:59
+msgid "View details for"
+msgstr "Details anzeigen für"
+
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:67
 msgid ""
 "Are you sure you want to download the submissions as a csv file? This file "
 "may contain sensitive information, so please handle it carefully."
@@ -3329,19 +3544,20 @@ msgstr ""
 "möchten? Diese Datei kann vertrauliche Informationen enthalten, daher "
 "behandeln Sie sie bitte vorsichtig."
 
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:29
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:69
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:49
 msgid "Export"
 msgstr "Exportieren"
 
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:40
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:94
 msgid "There are no"
 msgstr "Es gibt keine"
 
-#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:40
+#: hypha/apply/funds/templates/funds/includes/round-block-listing.html:94
 msgid "rounds"
 msgstr "Runden"
 
-#: hypha/apply/funds/templates/funds/includes/screening_status_block.html:5
+#: hypha/apply/funds/templates/funds/includes/screening_status_block.html:8
 msgid "Screening decision"
 msgstr "Entscheidung im Screening"
 
@@ -3355,85 +3571,82 @@ msgstr "Auswahl einreichen"
 msgid "Archived Submission"
 msgstr "Archivierte Einreichung"
 
+#: hypha/apply/funds/templates/funds/includes/submission-list-row.html:78
+msgid "submitted"
+msgstr "vorgelegt"
+
 #: hypha/apply/funds/templates/funds/includes/submission-list-row.html:202
-#: hypha/apply/funds/templates/funds/includes/submission-table-row.html:167
+#: hypha/apply/funds/templates/funds/includes/submission-table-row.html:166
 msgid "View communications"
 msgstr "Anzeigen von Kommunikationen"
 
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:14
-msgid "Selected"
-msgstr "Ausgewählt"
+#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:18
+msgid "selected"
+msgstr "ausgewählt"
 
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:36
-msgid "Hide Archived"
-msgstr "Archivierte ausblenden"
+#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:43
+msgid "Search..."
+msgstr "Suchen..."
 
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:41
-msgid "Show Archived"
-msgstr "Zeige Archiviert"
-
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:63
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:69
-msgid "Filters"
-msgstr "Filter"
-
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:74
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:84
-msgid "Search"
-msgstr "Suche"
-
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:80
-msgid "submissions"
-msgstr "Einreichungen"
-
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:87
+#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:46
 msgid "Search input"
 msgstr "Sucheingabe"
 
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:98
-#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:72
-msgid "Clear"
-msgstr "Löschen"
+#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:60
+#: hypha/apply/funds/templates/submissions/all.html:201
+msgid "Clear current filters & sorts"
+msgstr "Clear-Current-Filter & Sorts"
 
-#: hypha/apply/funds/templates/funds/includes/table_filter_and_search.html:99
-msgid "Filter by"
-msgstr "Filtern nach"
+#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:3
+msgid "Translate application"
+msgstr "Anwendung übersetzen"
 
-#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:59
+#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:38
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:10
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:26
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:50
+#: hypha/apply/projects/reports/templates/reports/report_form.html:24
+#: hypha/apply/projects/templates/application_projects/filters/widgets/date_range_input_widget.html:5
+msgid "to"
+msgstr "nach"
+
+#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:45
 msgid "Translations are an experimental feature and may be inaccurate"
 msgstr "Übersetzungen sind ein experimentelles Feature und können ungenau sein"
+
+#: hypha/apply/funds/templates/funds/includes/translate_application_form.html:68
+msgid "Clear"
+msgstr "Löschen"
 
 #: hypha/apply/funds/templates/funds/includes/update_reviewer_form.html:2
 msgid "Update reviewers"
 msgstr "Reviewer aktualisieren"
 
 #: hypha/apply/funds/templates/funds/includes/update_reviewer_form.html:52
-#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:19
-#: hypha/apply/funds/templates/submissions/submenu/bulk-update-reviewers.html:50
-#: hypha/apply/funds/views/submission_edit.py:545
-#: hypha/apply/funds/views/submission_edit.py:576
-#: hypha/apply/funds/views/submission_edit.py:605
-#: hypha/apply/funds/views/submission_edit.py:649
-#: hypha/apply/funds/views/submission_edit.py:682
-#: hypha/apply/funds/views/submission_edit.py:731
-#: hypha/apply/funds/views/submission_edit.py:762
-#: hypha/apply/funds/views/submission_edit.py:788
-#: hypha/apply/funds/views/translate.py:62
-#: hypha/apply/funds/views/translate.py:97
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:26
-#: hypha/apply/projects/views/project.py:417
-#: hypha/apply/projects/views/project.py:456
-#: hypha/apply/projects/views/project.py:500
-#: hypha/apply/projects/views/project.py:1238
-#: hypha/apply/projects/views/project.py:1277
+#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:20
+#: hypha/apply/funds/templates/submissions/submenu/bulk-update-reviewers.html:51
+#: hypha/apply/funds/views/submission_edit.py:535
+#: hypha/apply/funds/views/submission_edit.py:566
+#: hypha/apply/funds/views/submission_edit.py:595
+#: hypha/apply/funds/views/submission_edit.py:639
+#: hypha/apply/funds/views/submission_edit.py:672
+#: hypha/apply/funds/views/submission_edit.py:721
+#: hypha/apply/funds/views/submission_edit.py:752
+#: hypha/apply/funds/views/submission_edit.py:778
+#: hypha/apply/funds/views/translate.py:60
+#: hypha/apply/funds/views/translate.py:95
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:28
+#: hypha/apply/projects/views/payment.py:353
+#: hypha/apply/projects/views/project.py:423
+#: hypha/apply/projects/views/project.py:462
+#: hypha/apply/projects/views/project.py:506
+#: hypha/apply/projects/views/project.py:542
+#: hypha/apply/projects/views/project.py:1289
+#: hypha/apply/projects/views/project.py:1328
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: hypha/apply/funds/templates/funds/modals/create_project_form.html:2
-msgid "Create project"
-msgstr "Projekt erstellen"
-
-#: hypha/apply/funds/templates/funds/modals/create_project_form.html:5
+#: hypha/apply/funds/templates/funds/modals/create_project_form.html:6
 msgid ""
 "Are you sure you want create a project from this submission? This cannot be "
 "undone."
@@ -3441,21 +3654,92 @@ msgstr ""
 "Sind Sie sicher, dass Sie ein Projekt aus diesem Einreichung erstellen "
 "möchten? Dies kann nicht rückgängig gemacht werden."
 
+#: hypha/apply/funds/templates/funds/modals/create_reminder_form.html:2
+msgid "Create reminder"
+msgstr "Erinnerung erstellen"
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:3
+msgid "Edit co-applicant"
+msgstr "Bearbeiten: Mitbewerber"
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:19
+msgid "Update the role for co-applicant."
+msgstr "Aktualisiere die Stelle für den Mitbewerber."
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:21
+msgid "1. View: They can only view the application."
+msgstr "1. Ansicht: Sie können nur die Anwendung ansehen."
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:23
+msgid "2. Comment: They can view and write comment."
+msgstr "2. Kommentar: Sie können einen Kommentar ansehen und schreiben."
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:25
+msgid "3. Edit: They can view, comment and edit the application."
+msgstr ""
+"3. Bearbeiten: Sie können die Anwendung ansehen, kommentieren und bearbeiten."
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:49
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:73
+msgid "Are you sure you want to delete co-applicant?"
+msgstr "Bist du sicher, dass du den Mitbewerber streichen willst?"
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:51
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:83
+#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:79
+#: hypha/apply/todo/templates/todo/todolist_item.html:45
+msgid "Remove"
+msgstr "Entfernen"
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:56
+msgid ""
+"You can not update until co-applicant accepts the invite. You may re-invite "
+"them."
+msgstr ""
+"Sie können erst aktualisieren, wenn der Mitbewerber die Einladung angenommen "
+"hat. Sie können sie erneut einladen."
+
+#: hypha/apply/funds/templates/funds/modals/edit_co_applicant_form.html:66
+msgid "Re-invite"
+msgstr "Wiedereinladung"
+
+#: hypha/apply/funds/templates/funds/modals/invite_co_applicant_form.html:6
+#, python-format
+msgid ""
+"Enter an email address and then select a role to invite a co-applicant. The "
+"invitation will be valid for %(expiry)s days."
+msgstr ""
+"Geben Sie eine E-Mail-Adresse ein und wählen Sie dann eine Stelle aus, um "
+"einen Mitbewerber einzuladen. Die Einladung ist für %(expiry)s Tage gültig."
+
+#: hypha/apply/funds/templates/funds/modals/invite_co_applicant_form.html:10
+msgid "View: They can only read the application."
+msgstr "Ansicht: Sie können nur die Anwendung lesen."
+
+#: hypha/apply/funds/templates/funds/modals/invite_co_applicant_form.html:11
+msgid "Comment: They can view and add comments to the application."
+msgstr "Kommentar: Sie können die Bewerbung ansehen und Kommentare hinzufügen."
+
+#: hypha/apply/funds/templates/funds/modals/invite_co_applicant_form.html:12
+msgid "Edit: They can view, comment and edit the application."
+msgstr ""
+"Nachtrag: Sie können die Anwendung ansehen, kommentieren und bearbeiten."
+
 #: hypha/apply/funds/templates/funds/modals/progress_form.html:5
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:63
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:33
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:38
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:43
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:40
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:140
-#: hypha/apply/projects/views/project.py:994
-#: hypha/apply/projects/views/project.py:1209
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:78
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:15
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:20
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:25
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:46
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:137
+#: hypha/apply/projects/views/project.py:1043
+#: hypha/apply/projects/views/project.py:1260
 msgid "Update Status"
 msgstr "Status aktualisieren"
 
 #: hypha/apply/funds/templates/funds/modals/progress_form.html:10
 #: hypha/apply/projects/templates/application_projects/modals/invoice_status_update.html:5
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:37
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:19
 msgid "Current status"
 msgstr "Aktueller Status"
 
@@ -3470,34 +3754,34 @@ msgid "Current Lead"
 msgstr "Aktueller Lead"
 
 #: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:4
-#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:9
-#: hypha/apply/review/templates/review/review_confirm_delete.html:4
-#: hypha/apply/review/templates/review/review_confirm_delete.html:9
-#: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:4
-#: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:9
-msgid "Deleting"
-msgstr "Löschen"
+#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:8
+#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:36
+msgid "Delete reminder"
+msgstr "Erinnerung löschen"
 
-#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:16
-#, python-format
-msgid ">Are you sure you want to delete \"%(object)s\"?"
-msgstr ">Sind Sie sicher, dass Sie \"%(object)s\" löschen möchten?"
+#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:18
+msgid "Delete Reminder?"
+msgstr "Erinnerung löschen?"
 
-#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:17
-#: hypha/apply/funds/views/submission_edit.py:429
-#: hypha/apply/funds/views/submission_edit.py:471
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:30
-#: hypha/apply/projects/views/project.py:563
-#: hypha/apply/projects/views/project.py:622
-#: hypha/apply/review/templates/review/review_confirm_delete.html:17
-#: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:17
-#: hypha/apply/users/templates/elevate/elevate.html:32
-#: hypha/apply/users/templates/two_factor/admin/disable.html:22
-#: hypha/apply/users/templates/two_factor/profile/disable.html:36
-#: hypha/apply/users/templates/users/partials/confirmation_code_sent.html:43
-#: hypha/apply/users/views.py:308
-msgid "Confirm"
-msgstr "Bestätigen"
+#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:21
+msgid "Are you sure you want to delete this reminder scheduled "
+msgstr "Bist du sicher, dass du diese geplante Erinnerung löschen möchtest? "
+
+#: hypha/apply/funds/templates/funds/reminder_confirm_delete.html:22
+#: hypha/apply/projects/templates/application_projects/modals/approve_contract.html:7
+msgid "This cannot be undone."
+msgstr "Dies kann nicht rückgängig gemacht werden."
+
+#: hypha/apply/funds/templates/funds/reviewer_leaderboard.html:5
+#: hypha/apply/funds/templates/funds/reviewer_leaderboard_detail.html:5
+#: hypha/apply/funds/templates/funds/submissions_result.html:73
+#: hypha/apply/projects/templates/application_projects/paf_export.html:31
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:62
+#: hypha/apply/review/templates/review/review_list.html:4
+#: hypha/apply/review/templates/review/review_list.html:9
+#: hypha/core/navigation.py:80
+msgid "Reviews"
+msgstr "Bewertungen"
 
 #: hypha/apply/funds/templates/funds/reviewer_leaderboard.html:10
 msgid "Reviewer leaderboard"
@@ -3508,7 +3792,7 @@ msgstr "Bestenliste der Reviewer"
 msgid "Track and explore the reviews"
 msgstr "Verfolgen und erkunden Sie die Bewertungen"
 
-#: hypha/apply/funds/templates/funds/reviewer_leaderboard.html:16
+#: hypha/apply/funds/templates/funds/reviewer_leaderboard.html:20
 msgid "All reviewers"
 msgstr "Alle Reviewer"
 
@@ -3517,23 +3801,36 @@ msgstr "Alle Reviewer"
 msgid "Reviews by %(object)s"
 msgstr "Bewertungen von %(object)s"
 
+#: hypha/apply/funds/templates/funds/revisions_compare.html:3
+msgid "Compare"
+msgstr "Vergleichen"
+
+#: hypha/apply/funds/templates/funds/revisions_compare.html:8
+msgid "View all revisions"
+msgstr "Alle Überarbeitungen anzeigen"
+
 #: hypha/apply/funds/templates/funds/revisions_compare.html:9
-msgid "View revisions"
-msgstr "Revisionen anzeigen"
+msgid "Revision detail"
+msgstr "Überarbeitungsdetails"
 
-#: hypha/apply/funds/templates/funds/revisions_compare.html:13
-msgid "Comparing revisions"
-msgstr "Vergleichen von Revisionen"
+#: hypha/apply/funds/templates/funds/revisions_compare.html:10
+#, python-format
+msgid "For %(title)s"
+msgstr "Für %(title)s"
 
-#: hypha/apply/funds/templates/funds/revisions_compare.html:23
-msgid "Proposal Information (Old)"
-msgstr "Informationen zum Konzept (Alt)"
+#: hypha/apply/funds/templates/funds/revisions_compare.html:19
+msgid "Changes"
+msgstr "Änderungen"
 
-#: hypha/apply/funds/templates/funds/revisions_compare.html:27
-msgid "Proposal Information (New)"
-msgstr "Informationen zum Konzept (Neu)"
+#: hypha/apply/funds/templates/funds/revisions_compare.html:28
+msgid "↔"
+msgstr "↔"
 
-#: hypha/apply/funds/templates/funds/rounds.html:10
+#: hypha/apply/funds/templates/funds/revisions_compare.html:137
+msgid "view"
+msgstr "ansehen"
+
+#: hypha/apply/funds/templates/funds/rounds.html:11
 msgid "Explore current and past rounds"
 msgstr "Aktuelle und vergangene Runden erkunden"
 
@@ -3596,26 +3893,23 @@ msgstr ""
 "\n"
 "Wenn Sie innerhalb von 15 Minuten keine E-Mail erhalten, überprüfen Sie "
 "bitte Ihr Spam-Verzeichnis und kontaktieren Sie %(email)s für weitere "
-"Unterstützung."
+"Unterstützung.\n"
+"                "
 
-#: hypha/apply/funds/templates/funds/submission-success.html:55
+#: hypha/apply/funds/templates/funds/submission-success.html:54
 msgid "Go to your dashboard"
 msgstr "Gehen Sie zu Ihrem Dashboard"
 
-#: hypha/apply/funds/templates/funds/submission-success.html:62
-msgid "Continue editing"
-msgstr "Weiter bearbeiten"
-
-#: hypha/apply/funds/templates/funds/submission-success.html:69
+#: hypha/apply/funds/templates/funds/submission-success.html:68
 msgid "View your submission"
 msgstr "Zeigen Sie Ihre Einreichung an"
 
-#: hypha/apply/funds/templates/funds/submission-success.html:77
+#: hypha/apply/funds/templates/funds/submission-success.html:73
 #: hypha/apply/users/templates/users/login.html:4
-#: hypha/apply/users/templates/users/login.html:64
-#: hypha/apply/users/templates/users/password_reset/complete.html:13
+#: hypha/apply/users/templates/users/login.html:70
+#: hypha/apply/users/templates/users/password_reset/complete.html:14
 #: hypha/apply/users/templates/users/passwordless_login_signup.html:5
-#: hypha/templates/includes/user_menu.html:103
+#: hypha/templates/includes/user_menu.html:104
 msgid "Log in"
 msgstr "Log in"
 
@@ -3623,29 +3917,26 @@ msgstr "Log in"
 msgid "Sealed"
 msgstr "Geschlossen"
 
-#: hypha/apply/funds/templates/funds/submission_sealed.html:20
-msgid "This application is sealed until the round is closed"
-msgstr "Diese Einreichung ist gesperrt, bis die Runde geschlossen ist"
-
-#: hypha/apply/funds/templates/funds/submission_sealed.html:21
-msgid "The round ends on"
-msgstr "Die Runde endet am"
-
-#: hypha/apply/funds/templates/funds/submission_sealed.html:22
+#: hypha/apply/funds/templates/funds/submission_sealed.html:27
+#: hypha/templates/cotton/hero/header.html:11
 msgid "Go back"
 msgstr "Zurück gehen"
 
-#: hypha/apply/funds/templates/funds/submission_sealed.html:24
+#: hypha/apply/funds/templates/funds/submission_sealed.html:32
+msgid "This application is sealed until the round is closed"
+msgstr "Diese Einreichung ist gesperrt, bis die Runde geschlossen ist"
+
+#: hypha/apply/funds/templates/funds/submission_sealed.html:36
+msgid "The round ends on"
+msgstr "Die Runde endet am"
+
+#: hypha/apply/funds/templates/funds/submission_sealed.html:46
 msgid ""
 "As an admin you are allowed to access the application. However, this action "
 "will be recorded."
 msgstr ""
 "Als Administrator sind Sie berechtigt, auf die Anwendung zuzugreifen. Diese "
 "Aktion wird jedoch dokumentiert."
-
-#: hypha/apply/funds/templates/funds/submission_sealed.html:27
-msgid "View application"
-msgstr "Einreichung anzeigen"
 
 #: hypha/apply/funds/templates/funds/submissions_result.html:3
 #: hypha/apply/funds/templates/funds/submissions_result.html:8
@@ -3656,92 +3947,78 @@ msgstr "Einreichungsergebnisse"
 msgid "Track and explore submission results"
 msgstr "Verfolgen und erkunden Sie die Einreichungsergebnisse"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:14
-msgid "Summary"
-msgstr "Zusammenfassung"
-
-#: hypha/apply/funds/templates/funds/submissions_result.html:18
+#: hypha/apply/funds/templates/funds/submissions_result.html:19
 msgid "Amounts"
 msgstr "Anzahl"
 
 #: hypha/apply/funds/templates/funds/submissions_result.html:21
 msgid "Applied amounts"
-msgstr "beantragt Menge"
+msgstr "Beantragt Menge"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:22
-#: hypha/apply/funds/templates/funds/submissions_result.html:36
+#: hypha/apply/funds/templates/funds/submissions_result.html:23
+#: hypha/apply/funds/templates/funds/submissions_result.html:46
 msgid "Applied"
-msgstr "beantragt"
+msgstr "Beantragt"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:25
+#: hypha/apply/funds/templates/funds/submissions_result.html:29
 msgid "Accepted amounts"
 msgstr "Akzeptierte Beträge"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:26
-#: hypha/apply/funds/templates/funds/submissions_result.html:40
-#: hypha/apply/funds/workflows/constants.py:89
-#: hypha/apply/funds/workflows/definitions/double_stage.py:311
-#: hypha/apply/funds/workflows/definitions/single_stage.py:134
-#: hypha/apply/funds/workflows/definitions/single_stage_community.py:197
-#: hypha/apply/funds/workflows/definitions/single_stage_external.py:170
-#: hypha/apply/funds/workflows/definitions/single_stage_same.py:123
-msgid "Accepted"
-msgstr "Akzeptiert"
+#: hypha/apply/funds/templates/funds/submissions_result.html:42
+#: hypha/apply/funds/templates/submissions/all.html:7
+#: hypha/core/navigation.py:59 hypha/core/navigation.py:137
+msgid "Submissions"
+msgstr "Einreichungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:35
+#: hypha/apply/funds/templates/funds/submissions_result.html:44
 msgid "Applied submissions"
 msgstr "Eingereichte Einreichungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:39
+#: hypha/apply/funds/templates/funds/submissions_result.html:53
 msgid "Accepted submissions"
 msgstr "Akzeptierte Einreichungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:43
+#: hypha/apply/funds/templates/funds/submissions_result.html:61
 msgid "Pending submissions"
 msgstr "Ausstehende Einreichungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:44
-#: hypha/apply/projects/templates/application_projects/paf_export.html:22
-msgid "Pending"
-msgstr "Ausstehend"
-
-#: hypha/apply/funds/templates/funds/submissions_result.html:54
+#: hypha/apply/funds/templates/funds/submissions_result.html:75
 msgid "All reviews"
 msgstr "Alle Bewertungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:58
+#: hypha/apply/funds/templates/funds/submissions_result.html:83
 msgid "Your reviews"
 msgstr "Ihre Bewertungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:59
+#: hypha/apply/funds/templates/funds/submissions_result.html:85
 msgid "You"
 msgstr "Sie"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:62
+#: hypha/apply/funds/templates/funds/submissions_result.html:91
 msgid "Your average score"
 msgstr "Ihre Durchschnittspunktzahl"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:63
+#: hypha/apply/funds/templates/funds/submissions_result.html:93
 msgid "Your avg. score"
 msgstr "Ihre Durchschnittspunktzahl"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:73
-msgid "Submission value totals"
-msgstr "Gesamtwerte der Einreichungen"
+#: hypha/apply/funds/templates/funds/submissions_result.html:105
+msgid "Totals"
+msgstr "Summen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:79
+#: hypha/apply/funds/templates/funds/submissions_result.html:112
 msgid "Number of submissions"
 msgstr "Anzahl der Einreichungen"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:85
+#: hypha/apply/funds/templates/funds/submissions_result.html:118
 msgid "Average value"
 msgstr "Durchschnittswert"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:92
+#: hypha/apply/funds/templates/funds/submissions_result.html:125
 msgid "Total value"
 msgstr "Gesamtwert"
 
-#: hypha/apply/funds/templates/funds/submissions_result.html:101
+#: hypha/apply/funds/templates/funds/submissions_result.html:135
 #, python-format
 msgid ""
 "*%(count_diff)s submission(s) lack requested amount fields or data and are "
@@ -3750,213 +4027,130 @@ msgstr ""
 "*%(count_diff)s Einreichung(en) fehlen die angeforderten Betragsfelder oder "
 "Daten und werden nicht einbezogen."
 
-#: hypha/apply/funds/templates/funds/tables/table.html:23
-msgid "Screening decisions"
-msgstr "Überprüfungsentscheidungen"
-
 #: hypha/apply/funds/templates/funds/tables/table.html:24
-msgid "Review outcomes"
-msgstr "Bewertungergebnisse"
+#: hypha/apply/projects/templates/application_projects/tables/table.html:18
+msgid "Show"
+msgstr "Anzeigen"
 
-#: hypha/apply/funds/templates/funds/tables/table.html:37
-msgid "Awaiting"
-msgstr "wartend"
-
-#: hypha/apply/funds/templates/funds/tables/table.html:95
-msgid "Linked"
-msgstr "Verknüpft"
-
-#: hypha/apply/funds/templates/funds/tables/table.html:131
-#: hypha/apply/projects/templates/application_projects/tables/table.html:25
+#: hypha/apply/funds/templates/funds/tables/table.html:28
+#: hypha/apply/projects/templates/application_projects/tables/table.html:22
 msgid "items"
 msgstr "Elemente"
 
-#: hypha/apply/funds/templates/funds/tables/table.html:139
-#: hypha/apply/projects/templates/application_projects/tables/table.html:32
-#: hypha/templates/includes/pagination.html:6
-msgid "previous"
-msgstr "vorherige"
-
-#: hypha/apply/funds/templates/funds/tables/table.html:147
-#: hypha/apply/projects/templates/application_projects/tables/table.html:40
-msgid "Page"
-msgstr "Seite"
-
-#: hypha/apply/funds/templates/funds/tables/table.html:154
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:5
-#: hypha/apply/projects/templates/application_projects/tables/table.html:47
-#: hypha/templates/includes/pagination.html:14
-msgid "next"
-msgstr "weiter"
-
-#: hypha/apply/funds/templates/submissions/all.html:12
-#: hypha/core/navigation.py:44
+#: hypha/apply/funds/templates/submissions/all.html:11
+#: hypha/core/navigation.py:65
 msgid "All Submissions"
 msgstr "Alle Einreichungen"
 
-#: hypha/apply/funds/templates/submissions/all.html:16
+#: hypha/apply/funds/templates/submissions/all.html:12
 msgid "Search and filter all submissions"
 msgstr "Suchen und filtern Sie alle Einreichungen"
 
-#: hypha/apply/funds/templates/submissions/all.html:25
+#: hypha/apply/funds/templates/submissions/all.html:19
+#: hypha/apply/funds/templates/submissions/all.html:22
 msgid "Table view"
 msgstr "Tabellenansicht"
 
-#: hypha/apply/funds/templates/submissions/all.html:33
-msgid "List View"
+#: hypha/apply/funds/templates/submissions/all.html:27
+#: hypha/apply/funds/templates/submissions/all.html:30
+msgid "List view"
 msgstr "Listenansicht"
 
-#: hypha/apply/funds/templates/submissions/all.html:61
+#: hypha/apply/funds/templates/submissions/all.html:63
 msgid "Open submissions"
 msgstr "Offene Einreichungen"
 
-#: hypha/apply/funds/templates/submissions/all.html:73
+#: hypha/apply/funds/templates/submissions/all.html:75
 msgid "Your assigned submissions (lead)"
 msgstr "Ihre zugewiesenen Einreichungen (Lead)"
 
-#: hypha/apply/funds/templates/submissions/all.html:85
-msgid "Your flagged submissions"
-msgstr "Ihre gekennzeichneten Einreichungen"
-
-#: hypha/apply/funds/templates/submissions/all.html:97
+#: hypha/apply/funds/templates/submissions/all.html:99
 msgid "Staff flagged submissions"
 msgstr "Vom Team gekennzeichnete Einreichungen"
 
-#: hypha/apply/funds/templates/submissions/all.html:109
+#: hypha/apply/funds/templates/submissions/all.html:111
 msgid "Awaiting your review"
 msgstr "Warten auf Ihre Bewertung"
 
-#: hypha/apply/funds/templates/submissions/all.html:121
+#: hypha/apply/funds/templates/submissions/all.html:123
 msgid "Reviewed by you"
 msgstr "Von Ihnen überprüft"
 
-#: hypha/apply/funds/templates/submissions/all.html:139
+#: hypha/apply/funds/templates/submissions/all.html:141
 msgid "Search…"
 msgstr "Suchen…"
 
-#: hypha/apply/funds/templates/submissions/all.html:141
+#: hypha/apply/funds/templates/submissions/all.html:143
 msgid "Search submissions"
 msgstr "Suche nach Einreichungen"
 
-#: hypha/apply/funds/templates/submissions/all.html:171
+#: hypha/apply/funds/templates/submissions/all.html:168
 msgid "Drafts"
 msgstr "Entwürfe"
 
-#: hypha/apply/funds/templates/submissions/all.html:179
-msgid "Submissions: Download as CSV"
-msgstr "Einreichungen: Als CSV herunterladen"
-
-#: hypha/apply/funds/templates/submissions/all.html:182
-msgid "Export as CSV"
-msgstr "Als CSV exportieren"
-
-#: hypha/apply/funds/templates/submissions/all.html:204
-msgid "Clear current search query, filters and sorts"
-msgstr "Aktuelle Suchabfrage, Filter und Sortierungen löschen"
-
-#: hypha/apply/funds/templates/submissions/all.html:209
+#: hypha/apply/funds/templates/submissions/all.html:207
 msgid "Status:"
 msgstr "Status:"
 
 #: hypha/apply/funds/templates/submissions/all.html:212
-msgid "Remove status filter"
-msgstr "Statusfilter entfernen"
-
-#: hypha/apply/funds/templates/submissions/all.html:218
 msgid "Fund:"
 msgstr "Programm:"
 
-#: hypha/apply/funds/templates/submissions/all.html:221
-msgid "Remove fund filter"
-msgstr "Entfernen Sie den Programm-Filter"
-
-#: hypha/apply/funds/templates/submissions/all.html:227
+#: hypha/apply/funds/templates/submissions/all.html:217
 msgid "Round:"
 msgstr "Runde:"
 
-#: hypha/apply/funds/templates/submissions/all.html:230
-msgid "Remove round filter"
-msgstr "Rundenfilter entfernen"
-
-#: hypha/apply/funds/templates/submissions/all.html:236
+#: hypha/apply/funds/templates/submissions/all.html:222
 msgid "Lead:"
 msgstr "Lead:"
 
-#: hypha/apply/funds/templates/submissions/all.html:239
-msgid "Remove leads filter"
-msgstr "Leads-Filter entfernen"
-
-#: hypha/apply/funds/templates/submissions/all.html:245
+#: hypha/apply/funds/templates/submissions/all.html:227
 msgid "Applicant:"
 msgstr "Bewerber:"
 
-#: hypha/apply/funds/templates/submissions/all.html:248
-msgid "Remove applicant filter"
-msgstr "Entfernen Sie den Bewerberfilter"
-
-#: hypha/apply/funds/templates/submissions/all.html:254
+#: hypha/apply/funds/templates/submissions/all.html:232
 msgid "Reviewer:"
 msgstr "Reviewer:"
 
-#: hypha/apply/funds/templates/submissions/all.html:257
-msgid "Remove reviewer filter"
-msgstr "Entfernen des Reviewer-Filters"
-
-#: hypha/apply/funds/templates/submissions/all.html:263
+#: hypha/apply/funds/templates/submissions/all.html:237
 msgid "Tag:"
 msgstr "Tag:"
 
-#: hypha/apply/funds/templates/submissions/all.html:266
-msgid "Remove tag filter"
-msgstr "Entfernen Sie den Tag-Filter"
-
-#: hypha/apply/funds/templates/submissions/all.html:272
+#: hypha/apply/funds/templates/submissions/all.html:242
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: hypha/apply/funds/templates/submissions/all.html:275
-msgid "Remove category filter"
-msgstr "Kategorienfilter entfernen"
-
-#: hypha/apply/funds/templates/submissions/all.html:281
+#: hypha/apply/funds/templates/submissions/all.html:247
 msgid "Screening:"
 msgstr "Überprüfung:"
 
-#: hypha/apply/funds/templates/submissions/all.html:284
-msgid "Remove screening decisions filter"
-msgstr "Entscheidungsfilter für die Überprüfung entfernen"
-
-#: hypha/apply/funds/templates/submissions/all.html:290
+#: hypha/apply/funds/templates/submissions/all.html:252
 msgid "Sort:"
 msgstr "Sortieren:"
 
-#: hypha/apply/funds/templates/submissions/all.html:293
-msgid "Remove sort filter"
-msgstr "Sortierfilter entfernen"
-
-#: hypha/apply/funds/templates/submissions/all.html:353
+#: hypha/apply/funds/templates/submissions/all.html:311
 msgid "Select all submissions"
 msgstr "Wählen Sie alle Einreichungen"
 
-#: hypha/apply/funds/templates/submissions/all.html:360
+#: hypha/apply/funds/templates/submissions/all.html:318
 msgid "Select all"
 msgstr "Wählen Sie alles aus"
 
-#: hypha/apply/funds/templates/submissions/all.html:385
+#: hypha/apply/funds/templates/submissions/all.html:352
 msgid "All statuses"
 msgstr "Alle Statusse"
 
-#: hypha/apply/funds/templates/submissions/all.html:411
+#: hypha/apply/funds/templates/submissions/all.html:378
 #: hypha/apply/funds/templates/submissions/submenu/change-status.html:22
 msgid "No statuses found. Sorry about that."
 msgstr "Leider keine Statusse gefunden."
 
-#: hypha/apply/funds/templates/submissions/all.html:517
+#: hypha/apply/funds/templates/submissions/all.html:484
 msgid "Are you sure you want to archive the selected submissions?"
 msgstr ""
 "Sind Sie sicher, dass Sie die ausgewählten Einreichungen archivieren möchten?"
 
-#: hypha/apply/funds/templates/submissions/all.html:529
+#: hypha/apply/funds/templates/submissions/all.html:496
 msgid ""
 "Are you sure you want to delete the selected submissions? This action cannot "
 "be undone."
@@ -3964,95 +4158,87 @@ msgstr ""
 "Sind Sie sicher, dass Sie die ausgewählten Einreichungen löschen möchten? "
 "Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: hypha/apply/funds/templates/submissions/all.html:549
+#: hypha/apply/funds/templates/submissions/all.html:522
 msgid "No results matched your search"
 msgstr "Keine Ergebnisse zu Ihrer Suche gefunden"
 
-#: hypha/apply/funds/templates/submissions/all.html:550
+#: hypha/apply/funds/templates/submissions/all.html:523
 msgid "Try"
 msgstr "Versuchen"
 
-#: hypha/apply/funds/templates/submissions/all.html:550
+#: hypha/apply/funds/templates/submissions/all.html:523
 msgid "clearing"
 msgstr "Löschung"
 
-#: hypha/apply/funds/templates/submissions/all.html:550
+#: hypha/apply/funds/templates/submissions/all.html:523
 msgid "the current query and try again"
 msgstr "die aktuelle Abfrage und versuchen Sie es erneut"
 
-#: hypha/apply/funds/templates/submissions/all.html:562
-msgid "First Page"
-msgstr "Erste Seite"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:9
+msgid "Submissions: Export as CSV"
+msgstr "Einreichungen: Export als CSV"
 
-#: hypha/apply/funds/templates/submissions/all.html:564
-msgid "First"
-msgstr "Erstes"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:11
+msgid "Export as CSV"
+msgstr "Als CSV exportieren"
 
-#: hypha/apply/funds/templates/submissions/all.html:569
-msgid "Previous Page"
-msgstr "Vorherige Seite"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:12
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:72
+msgid ""
+"Are you sure you want to export the submissions as a CSV file? This file may "
+"contain sensitive information, so please handle it carefully."
+msgstr ""
+"Bist du sicher, dass du die Einsendungen als CSV-Datei exportieren möchtest? "
+"Diese Datei könnte sensible Informationen enthalten, bitte gehen Sie "
+"vorsichtig damit um."
 
-#: hypha/apply/funds/templates/submissions/all.html:571
-msgid "Previous"
-msgstr "Vorherige"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:22
+msgid "Submissions: Generating downloadable CSV"
+msgstr "Einreichungen: Erstellung herunterladbarer CSV"
 
-#: hypha/apply/funds/templates/submissions/all.html:576
-#, python-format
-msgid "Page %(page_number)s of %(total)s."
-msgstr "Seite %(page_number)s von %(total)s."
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:23
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:24
+msgid "Generating downloadable CSV..."
+msgstr "Erstelle von herunterladbarem CSV..."
 
-#: hypha/apply/funds/templates/submissions/all.html:583
-msgid "Next Page"
-msgstr "Nächste Seite"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:40
+msgid "Submissions: Download generated CSV"
+msgstr "Einreichungen: Generierte CSV herunterladen"
 
-#: hypha/apply/funds/templates/submissions/all.html:585
-#: hypha/apply/users/templates/two_factor/_wizard_actions.html:6
-#: hypha/apply/users/templates/two_factor/_wizard_actions.html:10
-#: hypha/apply/users/templates/two_factor/core/backup_tokens_password.html:40
-#: hypha/apply/users/templates/users/passwordless_login_signup.html:47
-msgid "Next"
-msgstr "Weiter"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:42
+msgid "Download generated CSV"
+msgstr "Generierte CSV herunterladen"
 
-#: hypha/apply/funds/templates/submissions/all.html:590
-msgid "Last Page"
-msgstr "Letzte Seite"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:62
+msgid "Submissions: Generate downloadable CSV"
+msgstr "Einreichungen: Herunterladbare CSV erstellen"
 
-#: hypha/apply/funds/templates/submissions/all.html:592
-msgid "Last"
-msgstr "Letzte"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:64
+msgid "Generation failed, click to retry generating downloadable CSV"
+msgstr ""
+"Generierung fehlgeschlagen, klicke, um erneut zu versuchen, herunterladbare "
+"CSV zu generieren"
 
-#: hypha/apply/funds/templates/submissions/all.html:619
-msgid "Last 7 Days"
-msgstr "Letzte 7 Tage"
+#: hypha/apply/funds/templates/submissions/partials/export-submission-button.html:66
+msgid "Generate downloadable CSV"
+msgstr "Erstellen Sie herunterladbare CSV"
 
-#: hypha/apply/funds/templates/submissions/all.html:620
-msgid "Last 30 Days"
-msgstr "Letzte 30 Tage"
-
-#: hypha/apply/funds/templates/submissions/all.html:621
-msgid "This Month"
-msgstr "Diesen Monat"
-
-#: hypha/apply/funds/templates/submissions/all.html:622
-msgid "Last Month"
-msgstr "Letzter Monat"
-
-#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:11
 #: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:12
+#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:13
 msgid "Update tags"
 msgstr "Aktualisieren von Tags"
 
-#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:14
+#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:15
 msgid "Add tags"
 msgstr "Hinzufügen von Tags"
 
-#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:22
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:4
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:17
+#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:23
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:5
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:14
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:45
+#: hypha/apply/funds/templates/submissions/partials/meta-terms-card.html:46
 msgid "--"
 msgstr "--"
 
@@ -4156,44 +4342,48 @@ msgstr "Alle Runden"
 msgid "No rounds available"
 msgstr "Keine Runden verfügbar"
 
-#: hypha/apply/funds/utils.py:188
+#: hypha/apply/funds/utils.py:197
 #, python-brace-format
 msgid "Copied on {copy_time}"
 msgstr "Kopiert am {copy_time}"
 
-#: hypha/apply/funds/views/all.py:58
+#: hypha/apply/funds/views/all.py:60
 msgid "No screening"
 msgstr "Keine Überprüfung"
 
-#: hypha/apply/funds/views/all.py:247
+#: hypha/apply/funds/views/all.py:251
 msgid "Newest"
 msgstr "Neueste"
 
-#: hypha/apply/funds/views/all.py:248
+#: hypha/apply/funds/views/all.py:252
 msgid "Oldest"
 msgstr "Älteste"
 
-#: hypha/apply/funds/views/all.py:249
+#: hypha/apply/funds/views/all.py:253
 msgid "Most Commented"
 msgstr "Meist kommentiert"
 
-#: hypha/apply/funds/views/all.py:250
+#: hypha/apply/funds/views/all.py:254
 msgid "Least Commented"
 msgstr "Am wenigsten kommentiert"
 
-#: hypha/apply/funds/views/all.py:251
+#: hypha/apply/funds/views/all.py:255
 msgid "Recently Updated"
 msgstr "Kürzlich aktualisiert"
 
-#: hypha/apply/funds/views/all.py:252
+#: hypha/apply/funds/views/all.py:256
 msgid "Least Recently Updated"
 msgstr "Zuletzt geupdated"
 
-#: hypha/apply/funds/views/all.py:253
+#: hypha/apply/funds/views/all.py:257
 msgid "Best Match"
 msgstr "Beste Übereinstimmung"
 
-#: hypha/apply/funds/views/all.py:383
+#: hypha/apply/funds/views/all.py:304
+msgid "Started CSV generation."
+msgstr "Ich habe mit der CSV-Generierung begonnen."
+
+#: hypha/apply/funds/views/all.py:405
 #, python-brace-format
 msgid ""
 "A determination already exists for the following submissions and they have "
@@ -4202,24 +4392,51 @@ msgstr ""
 "Eine Entscheidung existiert bereits für die folgenden Einreichungen und sie "
 "wurden ausgeschlossen: {submissions}"
 
-#: hypha/apply/funds/views/all.py:396
+#: hypha/apply/funds/views/all.py:418
 msgid "Submissions expect different forms - please contact admin"
 msgstr ""
 "Einreichungen erwarten unterschiedliche Formulare - bitte kontaktieren Sie "
 "den Administrator"
 
-#: hypha/apply/funds/views/all.py:409
+#: hypha/apply/funds/views/all.py:431
 msgid "Inconsistent states provided - please talk to an admin"
 msgstr "Inkonsistente Stati  - Bitte sprechen Sie mit einem Admin"
 
-#: hypha/apply/funds/views/all.py:436
+#: hypha/apply/funds/views/all.py:458
 msgid "Failed to update: "
 msgstr "Aktualisierung fehlgeschlagen: "
 
-#: hypha/apply/funds/views/all.py:441
+#: hypha/apply/funds/views/all.py:463
 #, python-brace-format
 msgid "Successfully updated status to {status}: "
 msgstr "Status erfolgreich auf {status} aktualisiert: "
+
+#: hypha/apply/funds/views/co_applicants.py:94
+msgid "Co-applicant invited"
+msgstr "Eingeladener Mitbewerber"
+
+#: hypha/apply/funds/views/co_applicants.py:234
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:74
+#: hypha/apply/projects/templates/application_projects/project_form.html:29
+#: hypha/apply/projects/views/payment.py:284
+#: hypha/apply/projects/views/project.py:2035
+#: hypha/apply/users/templates/users/account.html:54
+#: hypha/apply/users/templates/wagtailusers/users/edit.html:70
+#: hypha/apply/users/templates/wagtailusers/users/edit.html:98
+msgid "Save"
+msgstr "Speichern"
+
+#: hypha/apply/funds/views/co_applicants.py:254
+msgid "Co-applicant updated"
+msgstr "Mitantragsteller aktualisiert"
+
+#: hypha/apply/funds/views/co_applicants.py:282
+msgid "Co-applicant re-invited"
+msgstr "Mitbewerber erneut eingeladen"
+
+#: hypha/apply/funds/views/co_applicants.py:304
+msgid "Co-applicant deleted"
+msgstr "Mitantragsteller gelöscht"
 
 #: hypha/apply/funds/views/reminders.py:86
 msgid "Reminder created"
@@ -4233,49 +4450,63 @@ msgstr "Erstellen"
 msgid "Reminder deleted"
 msgstr "Erinnerung gelöscht"
 
-#: hypha/apply/funds/views/submission_edit.py:99
-#: hypha/apply/funds/views/submission_edit.py:266
+#: hypha/apply/funds/views/submission_edit.py:98
+#: hypha/apply/funds/views/submission_edit.py:261
 msgid "Draft saved"
 msgstr "Entwurf gespeichert"
 
-#: hypha/apply/funds/views/submission_edit.py:376
-#: hypha/apply/funds/views/submission_edit.py:402
+#: hypha/apply/funds/views/submission_edit.py:366
+#: hypha/apply/funds/views/submission_edit.py:392
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:96
 #: hypha/apply/funds/workflows/definitions/double_stage.py:133
 msgid "Progress"
 msgstr "Weiter"
 
-#: hypha/apply/funds/views/submission_edit.py:568
+#: hypha/apply/funds/views/submission_edit.py:419
+#: hypha/apply/funds/views/submission_edit.py:461
+#: hypha/apply/projects/views/project.py:605
+#: hypha/apply/projects/views/project.py:664
+#: hypha/apply/review/templates/review/review_confirm_delete.html:23
+#: hypha/apply/users/templates/elevate/elevate.html:31
+#: hypha/apply/users/templates/two_factor/admin/disable.html:22
+#: hypha/apply/users/templates/two_factor/profile/disable.html:36
+#: hypha/apply/users/templates/users/partials/confirmation_code_sent.html:43
+#: hypha/apply/users/views.py:308
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: hypha/apply/funds/views/submission_edit.py:558
 msgid "Submission Lead updated."
 msgstr "Lead aktualisiert."
 
-#: hypha/apply/funds/views/submission_edit.py:722
+#: hypha/apply/funds/views/submission_edit.py:712
 msgid "Partners updated successfully."
 msgstr "Partner erfolgreich aktualisiert."
 
-#: hypha/apply/funds/views/submission_edit.py:780
-msgid "Meta terms updated successfully."
-msgstr "Metabegriffe erfolgreich aktualisiert."
+#: hypha/apply/funds/views/submission_edit.py:770
+msgid "Tags updated successfully."
+msgstr "Tags wurden erfolgreich aktualisiert."
 
-#: hypha/apply/funds/views/translate.py:156
+#: hypha/apply/funds/views/translate.py:154
 #, python-brace-format
 msgid "Submission translated from {fl} to {tl}."
 msgstr "Einreichung übersetzt von {fl} nach {tl}."
 
-#: hypha/apply/funds/views/translate.py:169
+#: hypha/apply/funds/views/translate.py:167
 msgid "Submission translation failed. Contact your Administrator."
 msgstr ""
 "Übersetzung der Einreichung fehlgeschlagen. Kontaktieren Sie Ihren "
 "Administrator."
 
-#: hypha/apply/funds/views/translate.py:176
+#: hypha/apply/funds/views/translate.py:174
 msgid "Translation cleared."
 msgstr "Übersetzung gelöscht."
 
-#: hypha/apply/funds/workflows/constants.py:59
+#: hypha/apply/funds/workflows/constants.py:61
 msgid "Received"
 msgstr "Erhalten"
 
-#: hypha/apply/funds/workflows/constants.py:63
+#: hypha/apply/funds/workflows/constants.py:65
 #: hypha/apply/funds/workflows/definitions/double_stage.py:74
 #: hypha/apply/funds/workflows/definitions/double_stage.py:211
 #: hypha/apply/funds/workflows/definitions/single_stage.py:74
@@ -4284,27 +4515,29 @@ msgstr "Erhalten"
 msgid "Internal Review"
 msgstr "Interne Bewertung"
 
-#: hypha/apply/funds/workflows/constants.py:67
+#: hypha/apply/funds/workflows/constants.py:69
 msgid "Ready for Discussion"
 msgstr "Bereit zur Diskussion"
 
-#: hypha/apply/funds/workflows/constants.py:73
+#: hypha/apply/funds/workflows/constants.py:75
 msgid "More Information Requested"
 msgstr "Mehr Informationen angefordert"
 
-#: hypha/apply/funds/workflows/constants.py:77
+#: hypha/apply/funds/workflows/constants.py:79
 #: hypha/apply/funds/workflows/definitions/double_stage.py:165
 msgid "Invited for Proposal"
 msgstr "Zur Konzept­einreichung eingeladen"
 
-#: hypha/apply/funds/workflows/constants.py:81
+#: hypha/apply/funds/workflows/constants.py:83
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:73
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:173
 #: hypha/apply/funds/workflows/definitions/double_stage.py:258
 #: hypha/apply/funds/workflows/definitions/single_stage_community.py:142
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:115
 msgid "External Review"
 msgstr "Formelle Prüfung"
 
-#: hypha/apply/funds/workflows/constants.py:85
+#: hypha/apply/funds/workflows/constants.py:87
 #: hypha/apply/funds/workflows/definitions/single_stage.py:127
 #: hypha/apply/funds/workflows/definitions/single_stage_community.py:190
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:163
@@ -4312,6 +4545,8 @@ msgstr "Formelle Prüfung"
 msgid "Ready for Determination"
 msgstr "Bereit für Entscheidung"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:33
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:136
 #: hypha/apply/funds/workflows/definitions/double_stage.py:34
 #: hypha/apply/funds/workflows/definitions/double_stage.py:85
 #: hypha/apply/funds/workflows/definitions/double_stage.py:173
@@ -4330,6 +4565,10 @@ msgstr "Bereit für Entscheidung"
 msgid "Request More Information"
 msgstr "Mehr Informationen anfordern"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:34
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:124
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:137
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:158
 #: hypha/apply/funds/workflows/definitions/double_stage.py:35
 #: hypha/apply/funds/workflows/definitions/double_stage.py:174
 #: hypha/apply/funds/workflows/definitions/single_stage.py:34
@@ -4339,21 +4578,28 @@ msgstr "Mehr Informationen anfordern"
 msgid "Open Review"
 msgstr "Review eröffnen"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:35
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:59
 #: hypha/apply/funds/workflows/definitions/double_stage.py:36
 #: hypha/apply/funds/workflows/definitions/double_stage.py:60
 #: hypha/apply/funds/workflows/definitions/double_stage.py:86
 msgid "Ready For Preliminary Determination"
 msgstr "Bereit für vorläufige Entscheidung"
 
-#: hypha/apply/funds/workflows/definitions/double_stage.py:37
-#: hypha/apply/funds/workflows/definitions/double_stage.py:59
-#: hypha/apply/funds/workflows/definitions/double_stage.py:72
-#: hypha/apply/funds/workflows/definitions/double_stage.py:88
-#: hypha/apply/funds/workflows/definitions/double_stage.py:108
-#: hypha/apply/funds/workflows/definitions/double_stage.py:119
-msgid "Invite to Proposal"
-msgstr "Einladung zur Konzept­einreichung"
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:36
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:58
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:71
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:82
+msgid "Invite to Concept"
+msgstr "Einladung zum Konzept"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:37
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:57
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:83
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:126
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:139
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:160
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:182
 #: hypha/apply/funds/workflows/definitions/double_stage.py:38
 #: hypha/apply/funds/workflows/definitions/double_stage.py:58
 #: hypha/apply/funds/workflows/definitions/double_stage.py:89
@@ -4386,6 +4632,7 @@ msgstr "Einladung zur Konzept­einreichung"
 msgid "Dismiss"
 msgstr "Ablehnen"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:39
 #: hypha/apply/funds/workflows/definitions/double_stage.py:40
 #: hypha/apply/funds/workflows/definitions/single_stage.py:40
 #: hypha/apply/funds/workflows/definitions/single_stage_community.py:42
@@ -4394,10 +4641,12 @@ msgstr "Ablehnen"
 msgid "Need screening"
 msgstr "Benötigt Überprüfung"
 
-#: hypha/apply/funds/workflows/definitions/double_stage.py:41
-msgid "Concept Note Received"
-msgstr "Projekskizze erhalten"
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:40
+msgid "Idea Received"
+msgstr "Idee eingereicht"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:61
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:162
 #: hypha/apply/funds/workflows/definitions/double_stage.py:62
 #: hypha/apply/funds/workflows/definitions/double_stage.py:110
 #: hypha/apply/funds/workflows/definitions/double_stage.py:200
@@ -4416,6 +4665,8 @@ msgstr "Projekskizze erhalten"
 msgid "More information required"
 msgstr "Weitere Informationen erforderlich"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:69
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:170
 #: hypha/apply/funds/workflows/definitions/double_stage.py:70
 #: hypha/apply/funds/workflows/definitions/double_stage.py:208
 #: hypha/apply/funds/workflows/definitions/double_stage.py:255
@@ -4429,6 +4680,7 @@ msgstr "Weitere Informationen erforderlich"
 msgid "Close Review"
 msgstr "Schließen Sie die Bewertung"
 
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:70
 #: hypha/apply/funds/workflows/definitions/double_stage.py:71
 #: hypha/apply/funds/workflows/definitions/single_stage.py:72
 #: hypha/apply/funds/workflows/definitions/single_stage_community.py:67
@@ -4437,6 +4689,73 @@ msgstr "Schließen Sie die Bewertung"
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:67
 msgid "Need screening (revert)"
 msgstr "Benötigt Überprüfung (rückgängig machen)"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:81
+#: hypha/apply/funds/workflows/definitions/double_stage.py:87
+#: hypha/apply/funds/workflows/definitions/single_stage.py:87
+#: hypha/apply/funds/workflows/definitions/single_stage_same.py:82
+msgid "Open Review (revert)"
+msgstr "Öffne Bewertung (rückgängig machen)"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:85
+#: hypha/apply/funds/workflows/definitions/double_stage.py:122
+msgid "Ready for Preliminary Determination"
+msgstr "Bereit für vorläufige Entscheidung"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:92
+msgid "Idea Accepted"
+msgstr "Idee angenommen"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:93
+#: hypha/apply/funds/workflows/definitions/double_stage.py:130
+msgid "Preliminary Determination"
+msgstr "Vorläufige Entscheidung"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:125
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:138
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:159
+#: hypha/apply/funds/workflows/definitions/double_stage.py:162
+#: hypha/apply/funds/workflows/definitions/double_stage.py:176
+#: hypha/apply/funds/workflows/definitions/double_stage.py:197
+#: hypha/apply/funds/workflows/definitions/double_stage.py:224
+#: hypha/apply/funds/workflows/definitions/double_stage.py:267
+msgid "Ready For Final Determination"
+msgstr "Bereit für endgültige Entscheidung"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:128
+msgid "Invited for Concept"
+msgstr "Eingeladen für Concept"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:141
+msgid "Concept Received"
+msgstr "Konzept eingereicht"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:171
+msgid "Concept Received (revert)"
+msgstr "Konzept empfangen (rückgängig)"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:184
+#: hypha/apply/funds/workflows/definitions/double_stage.py:304
+msgid "Ready for Final Determination"
+msgstr "Bereit für endgültige Entscheidung"
+
+#: hypha/apply/funds/workflows/definitions/DH_idea_concept.py:192
+#: hypha/apply/funds/workflows/definitions/double_stage.py:312
+msgid "Final Determination"
+msgstr "Endgültige Entscheidung"
+
+#: hypha/apply/funds/workflows/definitions/double_stage.py:37
+#: hypha/apply/funds/workflows/definitions/double_stage.py:59
+#: hypha/apply/funds/workflows/definitions/double_stage.py:72
+#: hypha/apply/funds/workflows/definitions/double_stage.py:88
+#: hypha/apply/funds/workflows/definitions/double_stage.py:108
+#: hypha/apply/funds/workflows/definitions/double_stage.py:119
+msgid "Invite to Proposal"
+msgstr "Einladung zur Konzept­einreichung"
+
+#: hypha/apply/funds/workflows/definitions/double_stage.py:41
+msgid "Concept Note Received"
+msgstr "Projekskizze erhalten"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:75
 #: hypha/apply/funds/workflows/definitions/double_stage.py:212
@@ -4448,12 +4767,6 @@ msgstr "Benötigt Überprüfung (rückgängig machen)"
 #, python-brace-format
 msgid "{org_short_name} Review"
 msgstr "{org_short_name}-Bewertung"
-
-#: hypha/apply/funds/workflows/definitions/double_stage.py:87
-#: hypha/apply/funds/workflows/definitions/single_stage.py:87
-#: hypha/apply/funds/workflows/definitions/single_stage_same.py:82
-msgid "Open Review (revert)"
-msgstr "Öffne Bewertung (rückgängig machen)"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:91
 #: hypha/apply/funds/workflows/definitions/double_stage.py:228
@@ -4484,17 +4797,9 @@ msgstr "Bereit zur Diskussion"
 msgid "Ready For Discussion (revert)"
 msgstr "Bereit zur Diskussion (zurücksetzen)"
 
-#: hypha/apply/funds/workflows/definitions/double_stage.py:122
-msgid "Ready for Preliminary Determination"
-msgstr "Bereit für vorläufige Entscheidung"
-
 #: hypha/apply/funds/workflows/definitions/double_stage.py:129
 msgid "Concept Accepted"
 msgstr "Projekskizze akzeptiert"
-
-#: hypha/apply/funds/workflows/definitions/double_stage.py:130
-msgid "Preliminary Determination"
-msgstr "Vorläufige Entscheidung"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:161
 #: hypha/apply/funds/workflows/definitions/double_stage.py:175
@@ -4505,14 +4810,6 @@ msgstr "Vorläufige Entscheidung"
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:81
 msgid "Open External Review"
 msgstr "Externe Bewertung öffnen"
-
-#: hypha/apply/funds/workflows/definitions/double_stage.py:162
-#: hypha/apply/funds/workflows/definitions/double_stage.py:176
-#: hypha/apply/funds/workflows/definitions/double_stage.py:197
-#: hypha/apply/funds/workflows/definitions/double_stage.py:224
-#: hypha/apply/funds/workflows/definitions/double_stage.py:267
-msgid "Ready For Final Determination"
-msgstr "Bereit für endgültige Entscheidung"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:179
 msgid "Proposal Received"
@@ -4549,34 +4846,6 @@ msgstr "Externe Bewertung öffnen (zurücksetzen)"
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:112
 msgid "Accept but additional info required"
 msgstr "Akzeptieren, aber zusätzliche Informationen erforderlich"
-
-#: hypha/apply/funds/workflows/definitions/double_stage.py:270
-#: hypha/apply/funds/workflows/definitions/double_stage.py:301
-#: hypha/apply/funds/workflows/definitions/double_stage.py:318
-#: hypha/apply/funds/workflows/definitions/single_stage.py:37
-#: hypha/apply/funds/workflows/definitions/single_stage.py:60
-#: hypha/apply/funds/workflows/definitions/single_stage.py:89
-#: hypha/apply/funds/workflows/definitions/single_stage.py:111
-#: hypha/apply/funds/workflows/definitions/single_stage.py:124
-#: hypha/apply/funds/workflows/definitions/single_stage.py:141
-#: hypha/apply/funds/workflows/definitions/single_stage_community.py:154
-#: hypha/apply/funds/workflows/definitions/single_stage_community.py:187
-#: hypha/apply/funds/workflows/definitions/single_stage_community.py:204
-#: hypha/apply/funds/workflows/definitions/single_stage_external.py:127
-#: hypha/apply/funds/workflows/definitions/single_stage_external.py:160
-#: hypha/apply/funds/workflows/definitions/single_stage_external.py:177
-#: hypha/apply/funds/workflows/definitions/single_stage_same.py:113
-#: hypha/apply/funds/workflows/definitions/single_stage_same.py:130
-msgid "Accept"
-msgstr "Akzeptieren"
-
-#: hypha/apply/funds/workflows/definitions/double_stage.py:304
-msgid "Ready for Final Determination"
-msgstr "Bereit für endgültige Entscheidung"
-
-#: hypha/apply/funds/workflows/definitions/double_stage.py:312
-msgid "Final Determination"
-msgstr "Endgültige Entscheidung"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:321
 #: hypha/apply/funds/workflows/definitions/single_stage.py:144
@@ -4625,17 +4894,17 @@ msgid "Community Review"
 msgstr "Community Bewertung"
 
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:69
-#: hypha/apply/review/templates/review/review_detail.html:12
+#: hypha/apply/review/templates/review/review_detail.html:10
 msgid "Review"
 msgstr "Bewertung"
 
 #: hypha/apply/middleware.py:16
 msgid ""
 "The object you are trying to delete is used somewhere. Please remove any "
-"usages and try again!."
+"usages and try again!"
 msgstr ""
-"Das Objekt, das Sie löschen möchten, wird irgendwo verwendet. Bitte "
-"entfernen Sie alle Verwendungen und versuchen Sie es erneut!"
+"Das Objekt, das du löschen willst, wird irgendwo verwendet. Bitte entfernen "
+"Sie alle Verwendungen und versuchen Sie es erneut!"
 
 #: hypha/apply/projects/constants.py:17
 msgid "Staff pending"
@@ -4650,17 +4919,17 @@ msgid "Vendor pending"
 msgstr "Lieferant ausstehend"
 
 #: hypha/apply/projects/constants.py:22
-#: hypha/apply/projects/models/payment.py:35 hypha/apply/projects/utils.py:80
+#: hypha/apply/projects/models/payment.py:34 hypha/apply/projects/utils.py:91
 msgid "Declined"
 msgstr "Abgelehnt"
 
 #: hypha/apply/projects/constants.py:23
-#: hypha/apply/projects/models/payment.py:33 hypha/apply/projects/utils.py:82
+#: hypha/apply/projects/models/payment.py:32 hypha/apply/projects/utils.py:93
 msgid "Paid"
 msgstr "Bezahlt"
 
 #: hypha/apply/projects/constants.py:24
-#: hypha/apply/projects/models/payment.py:34 hypha/apply/projects/utils.py:84
+#: hypha/apply/projects/models/payment.py:33 hypha/apply/projects/utils.py:95
 msgid "Payment failed"
 msgstr "Zahlung fehlgeschlagen"
 
@@ -4671,10 +4940,6 @@ msgstr "{} ausstehend"
 #: hypha/apply/projects/constants.py:30
 msgid "Request for change"
 msgstr "Anfrage zur Änderung"
-
-#: hypha/apply/projects/filters.py:110
-msgid "Reporting Period"
-msgstr "Berichtszeitraum"
 
 #: hypha/apply/projects/forms/payment.py:108
 msgid "Invoice file"
@@ -4697,7 +4962,7 @@ msgid "Invoice File"
 msgstr "Rechnungsdatei"
 
 #: hypha/apply/projects/forms/payment.py:177
-#: hypha/apply/projects/forms/project.py:387
+#: hypha/apply/projects/forms/project.py:408
 msgid "Document"
 msgstr "Dokument"
 
@@ -4705,182 +4970,185 @@ msgstr "Dokument"
 msgid "File not found on submission"
 msgstr "Datei bei der Übermittlung nicht gefunden"
 
-#: hypha/apply/projects/forms/project.py:63
+#: hypha/apply/projects/forms/project.py:67
 msgid "Something changed before your approval please re-review"
 msgstr ""
 "Etwas hat sich vor Ihrer Genehmigung geändert, bitte überprüfen Sie erneut"
 
-#: hypha/apply/projects/forms/project.py:69
+#: hypha/apply/projects/forms/project.py:73
 msgid "The contract you were trying to approve has already been approved"
 msgstr "Der Vertrag, den Sie zu genehmigen versuchten, wurde bereits genehmigt"
 
-#: hypha/apply/projects/forms/project.py:73
+#: hypha/apply/projects/forms/project.py:77
 msgid "You can only approve a signed contract"
 msgstr "Sie können nur einen unterzeichneten Vertrag genehmigen"
 
-#: hypha/apply/projects/forms/project.py:89
-msgid "Select Project Lead"
-msgstr "Projekt Lead auswählen"
+#: hypha/apply/projects/forms/project.py:93
+msgid "Select project lead"
+msgstr "Projektleiter auswählen"
 
-#: hypha/apply/projects/forms/project.py:94
-msgid "Initial Project Status"
-msgstr "Anfangststatus des Projektes"
+#: hypha/apply/projects/forms/project.py:98
+msgid "Initial project status"
+msgstr "Ursprünglicher Projektstatus"
 
-#: hypha/apply/projects/forms/project.py:115
+#: hypha/apply/projects/forms/project.py:104
+msgid "Project end date"
+msgstr "Projekt-Enddatum"
+
+#: hypha/apply/projects/forms/project.py:123
 msgid "Project lead is a required field"
 msgstr "Projektlead ist ein erforderliches Feld"
 
-#: hypha/apply/projects/forms/project.py:197
+#: hypha/apply/projects/forms/project.py:222
 msgid "Project form status"
 msgstr "Status des Projektformulars"
 
-#: hypha/apply/projects/forms/project.py:286
+#: hypha/apply/projects/forms/project.py:307
 msgid "A Project can only be sent for Approval when Drafted."
 msgstr ""
 "Ein Projekt kann nur im Entwurfsstadium zur Genehmigung gesendet werden."
 
-#: hypha/apply/projects/forms/project.py:364
-#: hypha/apply/projects/forms/project.py:379
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:57
+#: hypha/apply/projects/forms/project.py:385
+#: hypha/apply/projects/forms/project.py:400
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:78
 msgid "Contract"
 msgstr "Vertrag"
 
-#: hypha/apply/projects/forms/project.py:366
+#: hypha/apply/projects/forms/project.py:387
 msgid "Signed and approved"
 msgstr "Unterschrieben und genehmigt"
 
-#: hypha/apply/projects/forms/project.py:403
+#: hypha/apply/projects/forms/project.py:424
 msgid "Contract Document"
 msgstr "Vertragsdokument"
 
-#: hypha/apply/projects/models/payment.py:28
+#: hypha/apply/projects/forms/project.py:482
+msgid "The end date must be after the start date."
+msgstr "Das Enddatum muss nach dem Startdatum liegen."
+
+#: hypha/apply/projects/models/payment.py:27
 msgid "Resubmitted"
 msgstr "Erneut eingereicht"
 
-#: hypha/apply/projects/models/payment.py:29
+#: hypha/apply/projects/models/payment.py:28
 msgid "Changes requested by staff"
 msgstr "Änderungen angefordert von Personal"
 
-#: hypha/apply/projects/models/payment.py:30
+#: hypha/apply/projects/models/payment.py:29
 msgid "Changes requested by finance"
 msgstr "Änderungen angefordert von Finanzen"
 
-#: hypha/apply/projects/models/payment.py:31
+#: hypha/apply/projects/models/payment.py:30
 msgid "Approved by staff"
 msgstr "Genehmigt vom Personal"
 
-#: hypha/apply/projects/models/payment.py:32
+#: hypha/apply/projects/models/payment.py:31
 msgid "Approved by finance"
 msgstr "Von Finanzen genehmigt"
 
-#: hypha/apply/projects/models/payment.py:117
-msgid "Message"
-msgstr "Nachricht"
-
-#: hypha/apply/projects/models/payment.py:120
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:22
+#: hypha/apply/projects/models/payment.py:122
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:27
 msgid "Invoice number"
 msgstr "Rechnungsnummer"
 
-#: hypha/apply/projects/models/payment.py:127
+#: hypha/apply/projects/models/payment.py:129
 msgid "Invoice amount"
 msgstr "Rechnungsbetrag"
 
-#: hypha/apply/projects/models/payment.py:129 hypha/apply/projects/tables.py:46
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:22
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:54
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:23
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:7
+#: hypha/apply/projects/models/payment.py:131 hypha/apply/projects/tables.py:45
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:25
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:56
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:30
 msgid "Invoice date"
 msgstr "Rechnungsdatum"
 
-#: hypha/apply/projects/models/payment.py:130
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:25
+#: hypha/apply/projects/models/payment.py:132
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:39
 msgid "Paid date"
 msgstr "Zahlungsdatum"
 
-#: hypha/apply/projects/models/payment.py:137
+#: hypha/apply/projects/models/payment.py:143
 #, python-brace-format
 msgid "Invoice requested for {project}"
 msgstr "Rechnung angefordert für {project}"
 
-#: hypha/apply/projects/models/project.py:83
+#: hypha/apply/projects/models/project.py:86
 msgid "Internal approval"
 msgstr "Interne Genehmigung"
 
-#: hypha/apply/projects/models/project.py:84
-#: hypha/apply/projects/models/project.py:92 hypha/apply/users/roles.py:13
+#: hypha/apply/projects/models/project.py:87
+#: hypha/apply/projects/models/project.py:95 hypha/apply/users/roles.py:13
 msgid "Contracting"
 msgstr "Verträge"
 
-#: hypha/apply/projects/models/project.py:85
-#: hypha/apply/projects/models/project.py:93
+#: hypha/apply/projects/models/project.py:88
+#: hypha/apply/projects/models/project.py:96
 msgid "Invoicing and reporting"
 msgstr "Rechnungsstellung und Berichterstattung"
 
-#: hypha/apply/projects/models/project.py:86
-#: hypha/apply/projects/models/project.py:94
+#: hypha/apply/projects/models/project.py:89
+#: hypha/apply/projects/models/project.py:97
 msgid "Closing"
 msgstr "Schließen"
 
-#: hypha/apply/projects/models/project.py:87
-#: hypha/apply/projects/models/project.py:95
+#: hypha/apply/projects/models/project.py:90
+#: hypha/apply/projects/models/project.py:98
 msgid "Complete"
 msgstr "Vervollständigt"
 
-#: hypha/apply/projects/models/project.py:91
+#: hypha/apply/projects/models/project.py:94
 msgid "{} approval"
 msgstr "{} Genehmigung"
 
-#: hypha/apply/projects/models/project.py:261
-msgid "Proposed Start Date"
+#: hypha/apply/projects/models/project.py:250
+msgid "Proposed start date"
 msgstr "Vorgeschlagener Starttermin"
 
-#: hypha/apply/projects/models/project.py:262
-msgid "Proposed End Date"
+#: hypha/apply/projects/models/project.py:252
+msgid "Proposed end date"
 msgstr "Vorgeschlagenes Enddatum"
 
-#: hypha/apply/projects/models/project.py:390
+#: hypha/apply/projects/models/project.py:400
 msgid "Proposed End Date must be after Proposed Start Date"
 msgstr ""
 "Das vorgeschlagene Enddatum muss nach dem vorgeschlagenen Startdatum liegen"
 
-#: hypha/apply/projects/models/project.py:539
+#: hypha/apply/projects/models/project.py:549
 msgid "user groups"
 msgstr "Benutzergruppen"
 
-#: hypha/apply/projects/models/project.py:541
+#: hypha/apply/projects/models/project.py:551
 msgid ""
 "Only selected group's users will be listed for this ProjectFormReviewerRole"
 msgstr ""
 "Nur die Benutzer der ausgewählten Gruppe werden für diese "
 "ProjectFormReviewerRole aufgelistet"
 
-#: hypha/apply/projects/models/project.py:561
+#: hypha/apply/projects/models/project.py:571
 msgid "Before"
 msgstr "Vorher"
 
-#: hypha/apply/projects/models/project.py:562
+#: hypha/apply/projects/models/project.py:572
 msgid "After"
 msgstr "Nach"
 
-#: hypha/apply/projects/models/project.py:571
+#: hypha/apply/projects/models/project.py:581
 msgid "Number of days"
 msgstr "Anzahl der Tage"
 
-#: hypha/apply/projects/models/project.py:572
+#: hypha/apply/projects/models/project.py:582
 msgid "Relation to report due date"
 msgstr "Beziehung zum Berichtsabgabetermin"
 
-#: hypha/apply/projects/models/project.py:597
+#: hypha/apply/projects/models/project.py:607
 msgid "Project Form Reviewers Roles"
 msgstr "Projektformular-Reviewerrollen"
 
-#: hypha/apply/projects/models/project.py:600
+#: hypha/apply/projects/models/project.py:610
 msgid "Project Reviewers Roles"
 msgstr "Projektreviewerrollen"
 
-#: hypha/apply/projects/models/project.py:602
+#: hypha/apply/projects/models/project.py:612
 msgid ""
 "Reviewer Roles are needed to move projects to 'Internal Approval' stage. "
 "Delete all roles to skip internal approval process and to move all internal "
@@ -4891,12 +5159,12 @@ msgstr ""
 "Genehmigungsprozess zu überspringen und alle internen Genehmigungsprojekte "
 "mit allen entfernten Genehmigungen auf den Status \"Entwurf\" zurückzusetzen."
 
-#: hypha/apply/projects/models/project.py:609
-#: hypha/apply/projects/models/project.py:610
+#: hypha/apply/projects/models/project.py:619
+#: hypha/apply/projects/models/project.py:620
 msgid "Report reminder frequency"
 msgstr "Erinnerungshäufigkeit für Berichte"
 
-#: hypha/apply/projects/models/project.py:612
+#: hypha/apply/projects/models/project.py:622
 msgid ""
 "Set up a cron job to run `notify_report_due.py`. The script will use these "
 "reminder settings."
@@ -4904,320 +5172,148 @@ msgstr ""
 "Ein Cron-Job einrichten, um `notify_report_due.py` auszuführen. Das Skript "
 "verwendet diese Erinnerungseinstellungen."
 
-#: hypha/apply/projects/models/project.py:642
+#: hypha/apply/projects/models/project.py:652
 #, python-brace-format
 msgid "Approval of {project} by {user}"
 msgstr "Genehmigung von {project} durch {user}"
 
-#: hypha/apply/projects/models/project.py:688
+#: hypha/apply/projects/models/project.py:698
 msgid "Counter Signed"
 msgstr "Gegenzeichnung"
 
-#: hypha/apply/projects/models/project.py:688
+#: hypha/apply/projects/models/project.py:698
 msgid "Unsigned"
 msgstr "Nicht signiert"
 
-#: hypha/apply/projects/models/project.py:691
+#: hypha/apply/projects/models/project.py:701
 #, python-brace-format
 msgid "Contract for {project} ({state})"
 msgstr "Vertrag für {project} ({state})"
 
-#: hypha/apply/projects/models/project.py:717
+#: hypha/apply/projects/models/project.py:727
 #, python-brace-format
 msgid "Project file: {title}"
 msgstr "Projektdatei: {title}"
 
-#: hypha/apply/projects/models/project.py:747
+#: hypha/apply/projects/models/project.py:757
 #, python-brace-format
 msgid "Contract file: {title}"
 msgstr "Vertragsdatei: {title}"
 
-#: hypha/apply/projects/models/project.py:787
+#: hypha/apply/projects/models/project.py:797
 msgid "Allow document access for groups"
 msgstr "Dokumentzugriff für Gruppen zulassen"
 
-#: hypha/apply/projects/models/project.py:788
+#: hypha/apply/projects/models/project.py:798
 msgid "Only selected group's users can access the document"
 msgstr "Nur Benutzer der ausgewählten Gruppe können auf das Dokument zugreifen"
 
-#: hypha/apply/projects/models/report.py:227
+#: hypha/apply/projects/reports/filters.py:39
+msgid "Reporting Period"
+msgstr "Berichtszeitraum"
+
+#: hypha/apply/projects/reports/models.py:234
 msgid "week"
 msgstr "Woche"
 
-#: hypha/apply/projects/models/report.py:228
+#: hypha/apply/projects/reports/models.py:235
 msgid "month"
 msgstr "Monat"
 
-#: hypha/apply/projects/models/report.py:229
+#: hypha/apply/projects/reports/models.py:236
 msgid "year"
 msgstr "Jahr"
 
-#: hypha/apply/projects/models/report.py:231
+#: hypha/apply/projects/reports/models.py:238
 msgid "Weeks"
 msgstr "Wochen"
 
-#: hypha/apply/projects/models/report.py:232
+#: hypha/apply/projects/reports/models.py:239
 msgid "Months"
 msgstr "Monate"
 
-#: hypha/apply/projects/models/report.py:233
+#: hypha/apply/projects/reports/models.py:240
 msgid "Years"
 msgstr "Jahre"
 
-#: hypha/apply/projects/models/report.py:247
-msgid "Reporting Disabled"
-msgstr "Berichterstellung deaktiviert"
+#: hypha/apply/projects/reports/models.py:259
+msgid "Disabled"
+msgstr "Arbeitsunfähig"
 
-#: hypha/apply/projects/models/report.py:252
+#: hypha/apply/projects/reports/models.py:264
 #, python-brace-format
 msgid "One time, that already has reported on {date}"
 msgstr "Einmal, das bereits am {date} gemeldet wurde"
 
-#: hypha/apply/projects/models/report.py:257
+#: hypha/apply/projects/reports/models.py:269
 #, python-brace-format
 msgid "One time on {date}"
 msgstr "Einmalig am {date}"
 
-#: hypha/apply/projects/models/report.py:265
-#: hypha/apply/projects/models/report.py:280
+#: hypha/apply/projects/reports/models.py:277
+#: hypha/apply/projects/reports/models.py:292
 msgid "last day"
 msgstr "letzter Tag"
 
-#: hypha/apply/projects/models/report.py:271
+#: hypha/apply/projects/reports/models.py:283
 #, python-brace-format
 msgid "Once a year on {month} {day}"
 msgstr "Einmal im Jahr am {month} {day}"
 
-#: hypha/apply/projects/models/report.py:274
+#: hypha/apply/projects/reports/models.py:286
 #, python-brace-format
 msgid "Every {occurrence} years on {month} {day}"
 msgstr "Jedes {occurrence} Jahre am {month} {day}"
 
-#: hypha/apply/projects/models/report.py:284
+#: hypha/apply/projects/reports/models.py:296
 #, python-brace-format
 msgid "Once a month on the {day}"
 msgstr "Einmal im Monat am {day}"
 
-#: hypha/apply/projects/models/report.py:285
+#: hypha/apply/projects/reports/models.py:297
 #, python-brace-format
 msgid "Every {occurrence} months on the {day}"
 msgstr "Jeden {occurrence} Monat am dem {day}"
 
-#: hypha/apply/projects/models/report.py:292
+#: hypha/apply/projects/reports/models.py:304
 #, python-brace-format
 msgid "Once a week on {weekday}"
 msgstr "Einmal wöchentlich am {weekday}"
 
-#: hypha/apply/projects/models/report.py:293
+#: hypha/apply/projects/reports/models.py:305
 #, python-brace-format
 msgid "Every {occurrence} weeks on {weekday}"
 msgstr "Jede {occurrence} Wochen am {weekday}"
 
-#: hypha/apply/projects/tables.py:27
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:24
-msgid "Invoice Number"
-msgstr "Rechnungsnummer"
-
-#: hypha/apply/projects/tables.py:50 hypha/apply/projects/tables.py:104
-#: hypha/apply/projects/tables.py:129
-msgid "Project Name"
-msgstr "Projektname"
-
-#: hypha/apply/projects/tables.py:70
-msgid "Vendor Name"
-msgstr "Name des Lieferanten"
-
-#: hypha/apply/projects/tables.py:172
-#: hypha/apply/projects/templates/application_projects/reporting.html:6
-#: hypha/apply/projects/templates/application_projects/reporting.html:11
-msgid "Reporting"
-msgstr "Berichterstellung"
-
-#: hypha/apply/projects/tables.py:232
-msgid "Date requested"
-msgstr "Gewünschtes Datum"
-
-#: hypha/apply/projects/tables.py:249
-msgid "Assignee"
-msgstr "Beauftragter"
-
-#: hypha/apply/projects/tables.py:269
-msgid "Waiting for approval"
-msgstr "Warten auf Genehmigung"
-
-#: hypha/apply/projects/tables.py:271
-msgid "Waiting for assignee"
-msgstr "Warten auf den Assignee"
-
-#: hypha/apply/projects/tables.py:294
-msgid "Project #"
-msgstr "Projekt #"
-
-#: hypha/apply/projects/tables.py:297
-msgid "Submission #"
-msgstr "Einreichung #"
-
-#: hypha/apply/projects/templates/application_projects/filters/widgets/date_range_input_widget.html:5
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:9
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:25
-#: hypha/apply/projects/templates/application_projects/report_detail.html:23
-#: hypha/apply/projects/templates/application_projects/report_form.html:31
-msgid "to"
-msgstr "nach"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:8
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:150
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:10
-msgid "Contracting documents"
-msgstr "Vertragsdokumente"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:15
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:69
-msgid "expand"
-msgstr "erweitern"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:29
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:97
-msgid "Submit contract documents"
-msgstr "Vertragsdokumente einreichen"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:39
-msgid "Approve contract documents"
-msgstr "Vertragsdokumente genehmigen"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:81
-msgid "Corrections/amendments?"
-msgstr "Korrekturen/Änderungen?"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:96
-msgid "Pending signed contract by "
-msgstr "Ausstehend unterschriebener Vertrag von "
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:96
-msgid "Signed contract by "
-msgstr "Unterschrift des Vertrags durch "
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:96
-msgid "Contracting team "
-msgstr "Vertrags-Team "
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:109
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:132
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:49
-#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:51
-#: hypha/apply/projects/views/project.py:650
-#: hypha/apply/projects/views/project.py:769
-#: hypha/apply/templates/forms/includes/field.html:32
-msgid "Upload"
-msgstr "Hochladen"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:111
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:134
-msgid "Reupload"
-msgstr "Neu hochladen"
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:120
-msgid "Pending countersigned contract by "
-msgstr "Ausstehend gegengezeichneter Vertrag von "
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:120
-msgid "Countersigned contract by "
-msgstr "Gegengezeichneter Vertrag von "
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:120
-msgid "you "
-msgstr "du "
-
-#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:120
-msgid "Vendor "
-msgstr "Lieferant "
-
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:12
-msgid "Add Invoice"
-msgstr "Rechnung hinzufügen"
-
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:21
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:53
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:6
-msgid "Date submitted"
-msgstr "Einreichungsdatum"
-
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:23
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:55
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status_table.html:8
-msgid "Invoice no."
-msgstr "Rechnungsnr."
-
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:33
-msgid "No active invoices yet."
-msgstr "Noch keine aktiven Rechnungen."
-
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:38
-msgid "Show rejected"
-msgstr "Zeige abgelehnt"
-
-#: hypha/apply/projects/templates/application_projects/includes/invoices.html:39
-msgid "Hide rejected"
-msgstr "Abgelehnt ausblenden"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:8
-msgid "Project documents"
-msgstr "Projektunterlagen"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:20
-msgid "Resubmit for approval"
-msgstr "Erneut zur Genehmigung einreichen"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:22
-msgid "Submit for approval"
-msgstr "Zur Genehmigung einreichen"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:35
-#: hypha/apply/projects/templates/application_projects/modals/update_pafapprovers.html:2
-msgid "View/Update Approvers"
-msgstr "Anzeige/Änderung der Genehmiger"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:43
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:120
-msgid "Change approver"
-msgstr "Genehmigender für Änderungen"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:53
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:131
-msgid "Assign approver"
-msgstr "Zuweisen des Genehmigenden"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:85
-msgid "Project form"
-msgstr "Projektformular"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:95
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:128
-msgid "Fill in"
-msgstr "Ausfüllen"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:116
-msgid "Scope of work"
-msgstr "Arbeitsumfang"
-
-#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:150
-#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:11
-msgid "Supporting documents"
-msgstr "Unterstützende Dokumente"
-
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:5
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:6
 msgid "The"
 msgstr "Der"
 
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:5
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:6
+msgid "current"
+msgstr "aktuell"
+
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:6
+msgid "next"
+msgstr "weiter"
+
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:6
 msgid "reporting period is"
 msgstr "Berichtszeitraum ist"
 
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:7
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:8
 msgid "A report is due for the period"
 msgstr "Ein Bericht ist für den Zeitraum fällig"
 
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:16
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:23
+msgid "Continue Editing"
+msgstr "Weiter bearbeiten"
+
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:23
+msgid "Add Report"
+msgstr "Bericht hinzufügen"
+
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:28
 #, python-format
 msgid ""
 " You're skipping the report for %(start_date)s - %(end_date)s. This will "
@@ -5225,109 +5321,427 @@ msgid ""
 msgstr ""
 " Sie überspringen den Bericht für %(start_date)s - %(end_date)s. Dies führt "
 "zu einer Lücke im Projektbericht. Sie können dies jederzeit rückgängig "
-"machen."
+"machen. "
 
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:17
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:20
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:29
+#: hypha/apply/projects/reports/templates/reports/includes/report_line.html:32
 msgid "Skip"
 msgstr "Überspringen"
 
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:31
-msgid "Continue Editing"
-msgstr "Weiter bearbeiten"
-
-#: hypha/apply/projects/templates/application_projects/includes/report_line.html:31
-msgid "Add Report"
-msgstr "Bericht hinzufügen"
-
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:8
-#: hypha/apply/projects/templates/application_projects/report_list.html:6
-#: hypha/core/navigation.py:93
-msgid "Reports"
-msgstr "Berichte"
-
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:24
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:26
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:50
-msgid "Past reports"
-msgstr "Vergangene Berichte"
-
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:56
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:65
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:55
 msgid "Period End"
 msgstr "Fristende"
 
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:89
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:101
 msgid "Unskip"
 msgstr "Unskip"
 
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:96
-msgid "No reports submitted"
-msgstr "Keine Berichte eingereicht"
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:116
+msgid "Show less"
+msgstr "Weniger anzeigen"
 
-#: hypha/apply/projects/templates/application_projects/includes/reports.html:103
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:116
 msgid "Show more"
 msgstr "Mehr anzeigen"
 
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:4
+#: hypha/apply/projects/reports/templates/reports/includes/reports.html:123
+msgid "No reports submitted yet."
+msgstr "Noch keine Berichte eingereicht."
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:2
+msgid "Change reporting frequency"
+msgstr "Berichtshäufigkeit ändern"
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:11
+msgid ""
+"You'll need to configure reporting before you can use it. Please set the "
+"report date and frequency, then save the form."
+msgstr ""
+"Du musst das Reporting konfigurieren, bevor du es verwenden kannst. Bitte "
+"setzen Sie das Meldedatum und die Häufigkeit ein und speichern Sie dann das "
+"Formular."
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:14
+msgid "No next report is due, One time reporting has already reported on "
+msgstr ""
+"Es ist kein nächster Bericht fällig, die Einmalberichterstattung hat bereits "
+"über berichtet "
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:17
+msgid "Next report will be due on "
+msgstr "Der nächste Bericht ist fällig am "
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:19
+msgid "and it will be one-time reporting."
+msgstr "und es wird eine einmalige Meldung sein."
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:22
+msgid "Next report will be due in"
+msgstr "Der nächste Bericht ist fällig in"
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:24
+msgid "and the report period will be"
+msgstr "und der Berichtszeitraum wird sein"
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:28
+msgid "and then every"
+msgstr "und dann jedes"
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:31
+msgid "after until the project end date"
+msgstr "bis nach dem Projekt-Enddatum"
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:56
+msgid "Report every:"
+msgstr "Bericht alle:"
+
+#: hypha/apply/projects/reports/templates/reports/modals/report_frequency_config.html:83
+msgid "Disable"
+msgstr "Abschalten"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:4
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:12
+msgid "Report"
+msgstr "Bericht"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:10
+#: hypha/apply/projects/reports/templates/reports/report_form.html:10
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:10
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:13
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:10
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:9
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:8
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:9
+msgid "View project"
+msgstr "Projekt ansehen"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:50
+#: hypha/apply/projects/reports/templates/reports/report_form.html:24
+msgid "This report is for the period"
+msgstr "Dieser Bericht ist für den Zeitraum"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:56
+msgid "Report Skipped"
+msgstr "Bericht übersprungen"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:58
+msgid "Public Report"
+msgstr "Öffentlicher Bericht"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:107
+msgid "View previous report"
+msgstr "Vorherigen Bericht anzeigen"
+
+#: hypha/apply/projects/reports/templates/reports/report_detail.html:115
+msgid "View next report"
+msgstr "Nächsten Bericht anzeigen"
+
+#: hypha/apply/projects/reports/templates/reports/report_form.html:4
+msgid "Edit Report"
+msgstr "Bericht bearbeiten"
+
+#: hypha/apply/projects/reports/templates/reports/report_form.html:12
+msgid "Submit a report"
+msgstr "Einen Bericht einreichen"
+
+#: hypha/apply/projects/reports/templates/reports/report_form.html:67
+msgid ""
+"Saving a draft means this report will be visible to you and staff from your "
+"project page."
+msgstr ""
+"Das Speichern eines Entwurfs bedeutet, dass dieser Bericht für Sie und das "
+"Projektteam auf Ihrer Projektseite sichtbar sein wird."
+
+#: hypha/apply/projects/reports/templates/reports/report_form.html:76
+msgid ""
+"Project report form not configured. Please add a project report form in the"
+msgstr ""
+"Projektberichtsformular nicht konfiguriert. Bitte fügen Sie ein "
+"Projektberichtsformular im Formular \"Folgendes\" hinzu"
+
+#: hypha/apply/projects/reports/templates/reports/report_form.html:78
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:66
+msgid "fund settings"
+msgstr "Programm-Einstellungen"
+
+#: hypha/apply/projects/reports/templates/reports/report_form.html:81
+msgid "Project report rorm not configured yet. Please contact us at "
+msgstr ""
+"Projektbericht RORM noch nicht konfiguriert. Bitte kontaktieren Sie uns "
+"unter "
+
+#: hypha/apply/projects/reports/templates/reports/report_list.html:11
+msgid "Submitted Reports"
+msgstr "Eingereichte Berichte"
+
+#: hypha/apply/projects/reports/templates/reports/report_list.html:12
+msgid "View and filter all Submitted Reports"
+msgstr "Anzeigen und Filtern aller eingereichten Berichte"
+
+#: hypha/apply/projects/reports/templates/reports/report_list.html:26
+msgid "No Reports Available."
+msgstr "Keine Berichte verfügbar."
+
+#: hypha/apply/projects/reports/templates/reports/reporting.html:6
+#: hypha/apply/projects/reports/templates/reports/reporting.html:11
+#: hypha/apply/projects/tables.py:186
+msgid "Reporting"
+msgstr "Berichterstellung"
+
+#: hypha/apply/projects/reports/templates/reports/reporting.html:12
+msgid "View, Search and filter reporting statuses"
+msgstr "Anzeigen, Suchen und Filtern von Berichtsstatus"
+
+#: hypha/apply/projects/reports/templates/reports/reporting.html:25
+msgid "No Projects Currently Reporting."
+msgstr "Derzeit werden keine Projekte gemeldet."
+
+#: hypha/apply/projects/reports/views.py:78
+#: hypha/apply/projects/reports/views.py:100
+msgid "You do not have permission to access this report."
+msgstr "Sie haben keine Erlaubnis, auf diesen Bericht zuzugreifen."
+
+#: hypha/apply/projects/reports/views.py:125
+msgid "You do not have permission to update this report."
+msgstr "Sie haben keine Erlaubnis, diesen Bericht zu aktualisieren."
+
+#: hypha/apply/projects/reports/views.py:372
+msgid "You do not have permission to update reporting configurations."
+msgstr ""
+"Sie haben keine Berechtigung, Berichtskonfigurationen zu aktualisieren."
+
+#: hypha/apply/projects/reports/views.py:491
+msgid "Reporting disabled"
+msgstr "Berichterstellung deaktiviert"
+
+#: hypha/apply/projects/tables.py:30
+msgid "Invoice #"
+msgstr "Rechnung #"
+
+#: hypha/apply/projects/tables.py:47
+msgid "Project Title"
+msgstr "Projekttitel"
+
+#: hypha/apply/projects/tables.py:103
+msgid "Vendor Name"
+msgstr "Name des Lieferanten"
+
+#: hypha/apply/projects/tables.py:137
+msgid "Project Name"
+msgstr "Projektname"
+
+#: hypha/apply/projects/tables.py:188
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:48
+msgid "End date"
+msgstr "Enddatum"
+
+#: hypha/apply/projects/tables.py:250
+msgid "Date requested"
+msgstr "Gewünschtes Datum"
+
+#: hypha/apply/projects/tables.py:265
+msgid "Assignee"
+msgstr "Beauftragter"
+
+#: hypha/apply/projects/tables.py:285
+msgid "Waiting for approval"
+msgstr "Warten auf Genehmigung"
+
+#: hypha/apply/projects/tables.py:287
+msgid "Waiting for assignee"
+msgstr "Warten auf den Assignee"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:16
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:190
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:10
+msgid "Contracting documents"
+msgstr "Vertragsdokumente"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:30
+msgid "Submit documents"
+msgstr "Dokumente einreichen"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:41
+msgid "Approve"
+msgstr "Billigen"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:53
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:89
+msgid "expand"
+msgstr "erweitern"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:88
+msgid "Corrections/amendments?"
+msgstr "Korrekturen/Änderungen?"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:113
+msgid "Pending signed contract by "
+msgstr "Ausstehend unterschriebener Vertrag von "
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:115
+msgid "Signed contract by "
+msgstr "Unterschrift des Vertrags durch "
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:117
+msgid "Contracting team "
+msgstr "Vertrags-Team "
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:136
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:170
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:60
+#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:56
+#: hypha/apply/projects/views/project.py:692
+#: hypha/apply/projects/views/project.py:815
+#: hypha/apply/templates/forms/includes/field.html:51
+msgid "Upload"
+msgstr "Hochladen"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:138
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:172
+msgid "Reupload"
+msgstr "Neu hochladen"
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:147
+msgid "Pending countersigned contract by "
+msgstr "Ausstehend gegengezeichneter Vertrag von "
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:149
+msgid "Countersigned contract by "
+msgstr "Gegengezeichneter Vertrag von "
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:151
+msgid "you "
+msgstr "du "
+
+#: hypha/apply/projects/templates/application_projects/includes/contracting_documents.html:151
+msgid "Vendor "
+msgstr "Lieferant "
+
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:14
+msgid "Add Invoice"
+msgstr "Rechnung hinzufügen"
+
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:24
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:55
+msgid "Date submitted"
+msgstr "Einreichungsdatum"
+
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:26
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:57
+msgid "Invoice no."
+msgstr "Rechnungsnr."
+
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:36
+msgid "No active invoices yet."
+msgstr "Noch keine aktiven Rechnungen."
+
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:41
+msgid "Show rejected"
+msgstr "Zeige abgelehnt"
+
+#: hypha/apply/projects/templates/application_projects/includes/invoices.html:42
+msgid "Hide rejected"
+msgstr "Abgelehnt ausblenden"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:17
+msgid "Project documents"
+msgstr "Projektunterlagen"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:29
+msgid "Resubmit for approval"
+msgstr "Erneut zur Genehmigung einreichen"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:31
+msgid "Submit for approval"
+msgstr "Zur Genehmigung einreichen"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:46
+msgid "Update approvers"
+msgstr "Update-Approver"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:55
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:156
+msgid "Change approver"
+msgstr "Genehmigender für Änderungen"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:67
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:168
+msgid "Assign approver"
+msgstr "Zuweisen des Genehmigenden"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:110
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:11
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:12
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:19
+msgid "Project form"
+msgstr "Projektformular"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:124
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:172
+msgid "Fill in"
+msgstr "Ausfüllen"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:149
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:9
+msgid "Scope of work"
+msgstr "Arbeitsumfang"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_documents.html:190
+#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:11
+msgid "Supporting documents"
+msgstr "Unterstützende Dokumente"
+
+#: hypha/apply/projects/templates/application_projects/includes/project_header.html:19
+msgid "View all applications in this round"
+msgstr "Alle Bewerbungen in dieser Runde ansehen"
+
 #: hypha/apply/projects/templates/application_projects/invoice_detail.html:4
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:15
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:41
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:4
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:19
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:11
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:69
 msgid "Invoice"
 msgstr "Rechnung"
 
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:11
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:12
-#: hypha/apply/projects/templates/application_projects/invoice_form.html:10
-#: hypha/apply/projects/templates/application_projects/project_approval_form.html:9
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:9
-#: hypha/apply/projects/templates/application_projects/report_detail.html:10
-#: hypha/apply/projects/templates/application_projects/report_form.html:14
-msgid "View project page"
-msgstr "Projektseite anzeigen"
-
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:14
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:25
-msgid "Delete Invoice"
-msgstr "Rechnung löschen"
-
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:23
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:27
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:42
 msgid "Vendor"
 msgstr "Lieferant"
 
-#: hypha/apply/projects/templates/application_projects/invoice_confirm_delete.html:29
-msgid "Are you sure you want to delete this invoice for"
-msgstr "Sind Sie sicher, dass Sie diese Rechnung für löschen möchten"
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:74
+msgid "Download invoice"
+msgstr "Rechnung herunterladen"
 
-#: hypha/apply/projects/templates/application_projects/invoice_detail.html:47
+#: hypha/apply/projects/templates/application_projects/invoice_detail.html:90
 #: hypha/apply/projects/templates/application_projects/paf_export.html:63
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:83
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:101
 msgid "Supporting Documents"
 msgstr "Unterstützende Dokumente"
 
-#: hypha/apply/projects/templates/application_projects/invoice_list.html:10
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:6
+#: hypha/apply/projects/templates/application_projects/invoice_form.html:14
+msgid "invoice"
+msgstr "Rechnung"
+
+#: hypha/apply/projects/templates/application_projects/invoice_list.html:11
 msgid "All Invoices"
 msgstr "Alle Rechnungen"
 
-#: hypha/apply/projects/templates/application_projects/invoice_list.html:11
+#: hypha/apply/projects/templates/application_projects/invoice_list.html:12
 msgid "View, search and filter all project invoices"
 msgstr "Anzeigen, Suchen und Filtern aller Projekt-Rechnungen"
 
-#: hypha/apply/projects/templates/application_projects/invoice_list.html:23
+#: hypha/apply/projects/templates/application_projects/invoice_list.html:20
 msgid "invoices"
 msgstr "Rechnungen"
 
-#: hypha/apply/projects/templates/application_projects/invoice_list.html:27
+#: hypha/apply/projects/templates/application_projects/invoice_list.html:24
 msgid "No Invoices available"
 msgstr "Keine Rechnungen verfügbar"
 
 #: hypha/apply/projects/templates/application_projects/modals/approve_contract.html:2
-msgid "Approve Contract"
+msgid "Approve contract"
 msgstr "Vertrag genehmigen"
 
 #: hypha/apply/projects/templates/application_projects/modals/approve_contract.html:6
@@ -5337,10 +5751,6 @@ msgid ""
 msgstr ""
 "Sind Sie sicher, dass Sie den Vertrag für den Beginn des Projekts "
 "akzeptieren und genehmigen möchten?"
-
-#: hypha/apply/projects/templates/application_projects/modals/approve_contract.html:7
-msgid "This cannot be undone."
-msgstr "Dies kann nicht rückgängig gemacht werden."
 
 #: hypha/apply/projects/templates/application_projects/modals/assign_pafapprovers.html:3
 msgid "Assign Approver"
@@ -5352,35 +5762,64 @@ msgstr "Genehmigender für Änderungen"
 
 #: hypha/apply/projects/templates/application_projects/modals/assign_pafapprovers.html:9
 msgid ""
-"Selected approver will be notified. On unselecting, every listed member here "
-"will be notified."
+"Selected approver will be notified. If no one is selected, every listed "
+"member here will be notified."
 msgstr ""
-"Der ausgewählte Genehmiger wird benachrichtigt. Bei der Aufhebung der "
-"Auswahl werden alle hier aufgeführten Mitglieder benachrichtigt."
+"Ausgewählte Genehmigungsperson wird benachrichtigt. Wenn niemand ausgewählt "
+"wird, wird jedes hier aufgeführte Mitglied benachrichtigt."
 
 #: hypha/apply/projects/templates/application_projects/modals/batch_invoice_status_update.html:2
 msgid "Update Invoices Status"
 msgstr "Aktualisieren Sie den Rechnungsstatus"
 
-#: hypha/apply/projects/templates/application_projects/modals/batch_invoice_status_update.html:7
-msgid " invoices selected"
-msgstr " Rechnungen ausgewählt"
+#: hypha/apply/projects/templates/application_projects/modals/batch_invoice_status_update.html:8
+#, python-format
+msgid ""
+"\n"
+"                    %(counter)s invoice selected\n"
+"                "
+msgid_plural ""
+"\n"
+"                    %(counter)s invoices selected\n"
+"                "
+msgstr[0] ""
+"\n"
+"%(counter)s Rechnung ausgewählt\n"
+"                "
+msgstr[1] ""
+"\n"
+"%(counter)s Rechnung ausgewählt\n"
+"                "
 
 #: hypha/apply/projects/templates/application_projects/modals/contracting_documents_upload.html:2
 msgid "Upload contracting documents"
 msgstr "Hochladen von Vertragsdokumenten"
 
+#: hypha/apply/projects/templates/application_projects/modals/invoice_confirm_delete.html:3
+msgid "Delete invoice"
+msgstr "Rechnung löschen"
+
+#: hypha/apply/projects/templates/application_projects/modals/invoice_confirm_delete.html:5
+msgid ""
+"Are you sure you want to delete this invoice? This action cannot be undone."
+msgstr ""
+"Bist du sicher, dass du diese Rechnung löschen willst? Diese Maßnahme kann "
+"nicht rückgängig gemacht werden."
+
 #: hypha/apply/projects/templates/application_projects/modals/invoice_status_update.html:2
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:36
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:18
 msgid "Update Invoice status"
 msgstr "Rechnungsstatus aktualisieren"
 
 #: hypha/apply/projects/templates/application_projects/modals/pafstatus_update.html:2
-msgid "Update Project Form Status"
-msgstr "Aktualisieren des Projektformularstatus"
+msgid "Project documents status"
+msgstr "Status der Projektdokumente"
+
+#: hypha/apply/projects/templates/application_projects/modals/project_dates_update.html:2
+msgid "Update project dates"
+msgstr "Aktualisierungsdaten des Projekts"
 
 #: hypha/apply/projects/templates/application_projects/modals/project_status_update.html:2
-#: hypha/apply/projects/templates/application_projects/project_admin_detail.html:31
 msgid "Update Project Status"
 msgstr "Projektstatus aktualisieren"
 
@@ -5388,80 +5827,19 @@ msgstr "Projektstatus aktualisieren"
 msgid "Update title"
 msgstr "Titel aktualisieren"
 
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:2
-msgid "Change reporting frequency"
-msgstr "Berichtshäufigkeit ändern"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:10
-msgid ""
-"Reporting has been disabled, just save the form with appropriate report date "
-"and frequency to enable it again."
-msgstr ""
-"Das Berichtswesen wurde deaktiviert, speichern Sie einfach das Formular mit "
-"dem entsprechenden Berichtsdatum und der Frequenz, um es wieder zu "
-"aktivieren."
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:13
-msgid "No next report is due, One time reporting has already reported on "
-msgstr ""
-"Es ist kein nächster Bericht fällig, die Einmalberichterstattung hat bereits "
-"über berichtet "
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:16
-msgid "Next report will be due on "
-msgstr "Der nächste Bericht ist fällig am "
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:18
-msgid "and it will be one-time reporting."
-msgstr "und es wird eine einmalige Meldung sein."
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:21
-msgid "Next report will be due in"
-msgstr "Der nächste Bericht ist fällig in"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:23
-msgid "and the report period will be"
-msgstr "und der Berichtszeitraum wird sein"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:27
-msgid "and then every"
-msgstr "und dann jedes"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:30
-msgid "after until the project end date"
-msgstr "bis nach dem Projekt-Enddatum"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:52
-msgid "Report every:"
-msgstr "Bericht alle:"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:68
-#: hypha/apply/projects/templates/application_projects/project_form.html:32
-#: hypha/apply/projects/views/payment.py:260
-#: hypha/apply/projects/views/payment.py:329
-#: hypha/apply/projects/views/project.py:1962
-#: hypha/apply/users/templates/wagtailusers/users/edit.html:70
-#: hypha/apply/users/templates/wagtailusers/users/edit.html:98
-msgid "Save"
-msgstr "Speichern"
-
-#: hypha/apply/projects/templates/application_projects/modals/report_frequency_config.html:69
-msgid "Disable Reporting"
-msgstr "Berichterstellung deaktivieren"
-
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:2
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:3
 msgid "Submit documents for review"
 msgstr "Dokumente zur Bewertung einreichen"
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:7
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:8
 msgid "Looks like the following documents are missing"
 msgstr "Es sieht so aus, als ob die folgenden Dokumente fehlen"
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:15
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:16
 msgid "Submit anyway"
 msgstr "In jedem Fall einreichen"
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:20
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:21
 msgid ""
 "This will submit the project documents for review by the configured "
 "approvers."
@@ -5469,15 +5847,15 @@ msgstr ""
 "Dies wird die Projektunterlagen zur Überprüfung dem konfigurierten "
 "Genehmiger zuweisen."
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:21
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:22
 msgid "Approvers will review sequentially in order."
 msgstr "Genehmigende überprüfen nacheinander laut Reihenfolge."
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:21
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:22
 msgid "Approvers can review in parallel at any time."
 msgstr "Genehmigende können parallel und jederzeit überprüfen."
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:25
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:26
 msgid ""
 "Note: All group members will be notified unless specific approvers are "
 "selected below."
@@ -5485,21 +5863,21 @@ msgstr ""
 "Hinweis: Alle Gruppenmitglieder werden benachrichtigt, sofern unten kein "
 "bestimmter Genehmiger ausgewählt wurde."
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:30
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:29
 msgid "Select approvers "
 msgstr "Genehmigende auswählen "
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:30
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:29
 msgid "Optional"
 msgstr "Optional"
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:38
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:34
 msgid "No reviewer roles configured. Please add roles in "
 msgstr ""
 "Keine Reviewer-Rollen konfiguriert. Bitte fügen Sie Rollen in <a href=\"{url}"
 "\">Admin</a> hinzu "
 
-#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:39
+#: hypha/apply/projects/templates/application_projects/modals/send_for_approval.html:35
 msgid "project settings"
 msgstr "Projekteinstellungen"
 
@@ -5520,9 +5898,13 @@ msgstr ""
 "Vertragsdokumente hochgeladen haben."
 
 #: hypha/apply/projects/templates/application_projects/modals/supporting_documents_upload.html:2
-#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:48
+#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:53
 msgid "Upload Supporting Documents"
 msgstr "Hochladen von unterstützenden Dokumenten"
+
+#: hypha/apply/projects/templates/application_projects/modals/update_pafapprovers.html:2
+msgid "View/Update Approvers"
+msgstr "Anzeige/Änderung der Genehmiger"
 
 #: hypha/apply/projects/templates/application_projects/modals/update_pafapprovers.html:6
 msgid "Are you sure you want to update the approvers?"
@@ -5548,89 +5930,117 @@ msgid " project settings"
 msgstr " Projekteinstellungen"
 
 #: hypha/apply/projects/templates/application_projects/modals/upload_contract.html:3
-msgid "Upload Countersigned Contract"
-msgstr "Hochladen des gegengezeichneten Vertrags"
+msgid "Upload countersigned contract"
+msgstr "Gegenunterzeichneter Vertrag hochladen"
 
 #: hypha/apply/projects/templates/application_projects/modals/upload_contract.html:5
-msgid "Upload Signed Contract"
-msgstr "Hochladen des unterzeichneten Vertrags"
+msgid "Upload signed contract"
+msgstr "Upload unterschriebenen Vertrag"
 
-#: hypha/apply/projects/templates/application_projects/modals/upload_contract.html:10
+#: hypha/apply/projects/templates/application_projects/modals/upload_contract.html:11
 msgid ""
-"The signed contract will be sent to Applicant once you submit. But if you "
-"select Signed and approved then it will directly be approved and project "
-"will move to Invoicing and Reporting."
+"Upload a signed contract that will sent to applicant for countersigning."
 msgstr ""
-"Der unterzeichnete Vertrag wird an den Antragsteller gesendet, sobald Sie "
-"senden. Wenn Sie jedoch \"Unterzeichnet und genehmigt\" auswählen, wird er "
-"direkt genehmigt und das Projekt wird zu Rechnungsstellung und "
-"Berichterstattung übergehen."
+"Laden Sie einen unterschriebenen Vertrag hoch, der an den Antragsteller zur "
+"Gegenunterzeichnung gesendet wird."
+
+#: hypha/apply/projects/templates/application_projects/modals/upload_contract.html:14
+msgid ""
+"NOTE: Selecting \"Signed and approved\" indicates the uploaded contract is "
+"already signed by both parties and the current project will move to the "
+"invoicing & reporting stage."
+msgstr ""
+"HINWEIS: Die Auswahl von \"Unterschrieben und genehmigt\" bedeutet, dass der "
+"hochgeladene Vertrag bereits von beiden Parteien unterschrieben ist und das "
+"aktuelle Projekt in die Rechnungs- und Berichtsphase übergeht."
 
 #: hypha/apply/projects/templates/application_projects/paf_export.html:6
 #: hypha/apply/projects/templates/application_projects/sow_export.html:6
 msgid "Project title"
 msgstr "Projekttitle"
 
+#: hypha/apply/projects/templates/application_projects/paf_export.html:7
+#: hypha/apply/projects/templates/application_projects/sow_export.html:7
+msgid "Project ID"
+msgstr "Projekt-ID"
+
 #: hypha/apply/projects/templates/application_projects/paf_export.html:18
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:45
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:44
 msgid "Approvals"
 msgstr "Genehmigungen"
 
 #: hypha/apply/projects/templates/application_projects/paf_export.html:32
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:58
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:66
 msgid "Submission lead"
 msgstr "Lead der Einreichung"
 
 #: hypha/apply/projects/templates/application_projects/paf_export.html:34
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:61
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:69
 msgid "Staff reviewers"
 msgstr "Team-Reviewer"
 
 #: hypha/apply/projects/templates/application_projects/paf_export.html:51
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:73
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:86
 msgid "Advisory council"
 msgstr "Beratungsgremium"
 
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:22
-msgid "Pending "
-msgstr "Ausstehend "
-
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:30
-#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:29
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:36
+#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:28
 msgid "View template"
 msgstr "Vorlage anzeigen"
 
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:46
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:57
 msgid "Upload Contracting Documents"
 msgstr "Hochladen von Vertragsdokumenten"
 
-#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:73
-#: hypha/apply/projects/templates/application_projects/partials/supporting_documents.html:76
-msgid "Remove"
-msgstr "Entfernen"
+#: hypha/apply/projects/templates/application_projects/partials/contracting_category_documents.html:106
+msgid "Submit contract documents"
+msgstr "Vertragsdokumente einreichen"
 
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:8
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:35
 msgid ""
 "Only editable when 'Submitted' or you have been requested to make changes"
 msgstr ""
 "Nur bearbeitbar, wenn 'Eingereicht' oder Sie wurden aufgefordert, Änderungen "
 "vorzunehmen"
 
-#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:17
+#: hypha/apply/projects/templates/application_projects/partials/invoice_detail_actions.html:46
 msgid "Edit Invoice"
 msgstr "Rechnung bearbeiten"
 
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:17
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:30
-#: hypha/apply/projects/templates/application_projects/project_detail.html:136
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:29
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:52
+#: hypha/apply/projects/templates/application_projects/project_detail.html:138
 msgid "View comment"
 msgstr "Kommentar ansehen"
 
-#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:46
-msgid "Hide"
-msgstr "Verbergen"
+#: hypha/apply/projects/templates/application_projects/partials/invoice_status.html:69
+msgid "show less"
+msgstr "Weniger anzeigen"
 
-#: hypha/apply/projects/templates/application_projects/partials/project_title.html:13
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:5
+msgid "Contractor"
+msgstr "Auftragnehmer"
+
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:22
+msgid "Start date"
+msgstr "Startdatum"
+
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:31
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:57
+msgid "edit dates"
+msgstr "Bearbeitungsdaten"
+
+#: hypha/apply/projects/templates/application_projects/partials/project_information.html:41
+msgid "Awaiting contract finalization..."
+msgstr "Warten auf Vertragsabschluss..."
+
+#: hypha/apply/projects/templates/application_projects/partials/project_lead.html:10
+#: hypha/apply/projects/templates/application_projects/partials/project_lead.html:14
+msgid "Project lead"
+msgstr "Projektleitung"
+
+#: hypha/apply/projects/templates/application_projects/partials/project_title.html:14
 msgid "edit title"
 msgstr "Titel bearbeiten"
 
@@ -5638,100 +6048,95 @@ msgstr "Titel bearbeiten"
 msgid "Invoice Status"
 msgstr "Rechnungsstatus"
 
-#: hypha/apply/projects/templates/application_projects/pdf_invoice_approved_page.html:16
+#: hypha/apply/projects/templates/application_projects/pdf_invoice_approved_page.html:12
+#, python-format
+msgid ""
+"<strong> %(activity_status)s (%(email)s)</strong> on %(time)s %(TIME_ZONE)s"
+msgstr ""
+"<strong> %(activity_status)s (%(email)s)</strong> auf %(time)s %(TIME_ZONE)s"
+
+#: hypha/apply/projects/templates/application_projects/pdf_invoice_approved_page.html:19
 msgid "Generated"
 msgstr "Erzeugt"
+
+#: hypha/apply/projects/templates/application_projects/project_admin_detail.html:16
+msgid ""
+"Please ensure the Project Form is completed and you are ready to proceed to "
+"the next stage. This action cannot be reverted."
+msgstr ""
+"Bitte stellen Sie sicher, dass das Projektformular ausgefüllt ist und Sie "
+"bereit sind, in die nächste Phase überzugehen. Diese Aktion kann nicht "
+"rückgängig gemacht werden."
 
 #: hypha/apply/projects/templates/application_projects/project_admin_detail.html:19
 msgid "Continue to next status"
 msgstr "Mit dem nächsten Status fortfahren"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:10
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:8
-msgid "Back to Project"
-msgstr "Zurück zum Projekt"
+#: hypha/apply/projects/templates/application_projects/project_admin_detail.html:28
+msgid "Update project status"
+msgstr "Aktualisieren Sie den Projektstatus"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:29
-#: hypha/apply/projects/templates/application_projects/project_detail.html:57
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:23
+#: hypha/apply/projects/templates/application_projects/project_detail.html:55
 msgid "Project Information"
 msgstr "Projektinformationen"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:51
-msgid " - Pending"
-msgstr " - Ausstehend"
-
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:71
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:79
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:83
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:94
 msgid "No reviews"
 msgstr "Keine Bewertungen"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:103
-msgid "Download Project Form"
-msgstr "Projektformular herunterladen"
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:174
+msgid "Download"
+msgstr "Herunterladen"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:107
+#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:182
 #: hypha/apply/projects/templates/application_projects/project_sow_detail.html:57
-msgid "Download as PDF"
-msgstr "Herunterladen als PDF"
-
-#: hypha/apply/projects/templates/application_projects/project_approval_detail.html:109
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:60
 msgid "Download as DOCX"
 msgstr "Herunterladen als DOCX"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_form.html:50
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:48
-msgid "Proposal attachments"
-msgstr "Anlagen zum Konzept"
-
-#: hypha/apply/projects/templates/application_projects/project_approval_form.html:63
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:65
 msgid "Project Form not configured. Please add an project form in the"
 msgstr ""
 "Projektformular nicht konfiguriert. Bitte fügen Sie ein Projektformular im"
 
-#: hypha/apply/projects/templates/application_projects/project_approval_form.html:64
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:61
-#: hypha/apply/projects/templates/application_projects/report_form.html:67
-msgid "fund settings"
-msgstr "Programm-Einstellungen"
+#: hypha/apply/projects/templates/application_projects/project_approval_form.html:75
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:67
+msgid "Proposal attachments"
+msgstr "Anlagen zum Konzept"
 
-#: hypha/apply/projects/templates/application_projects/project_detail.html:47
+#: hypha/apply/projects/templates/application_projects/project_detail.html:46
 #, python-format
 msgid " This project is in %(status)s state. "
-msgstr " Dieses Projekt befindet sich im %(status)s -Status."
-
-#: hypha/apply/projects/templates/application_projects/project_detail.html:60
-msgid "Contractor"
-msgstr "Auftragnehmer"
+msgstr " Dieses Projekt befindet sich im %(status)s -Status. "
 
 #: hypha/apply/projects/templates/application_projects/project_detail.html:120
 msgid "Project form approvals"
 msgstr "Projektformulargenehmigungen"
 
-#: hypha/apply/projects/templates/application_projects/project_detail.html:131
+#: hypha/apply/projects/templates/application_projects/project_detail.html:133
 msgid "Request changes or more information by "
 msgstr "Fordern Sie Änderungen oder weitere Informationen bis "
 
-#: hypha/apply/projects/templates/application_projects/project_detail.html:146
+#: hypha/apply/projects/templates/application_projects/project_detail.html:150
 msgid "Pending approval from "
 msgstr "Ausstehende Genehmigung von "
 
-#: hypha/apply/projects/templates/application_projects/project_detail.html:150
+#: hypha/apply/projects/templates/application_projects/project_detail.html:154
 msgid "nobody assigned yet"
 msgstr "noch nicht zugewiesen"
 
-#: hypha/apply/projects/templates/application_projects/project_detail.html:158
+#: hypha/apply/projects/templates/application_projects/project_detail.html:162
 msgid "approved"
 msgstr "genehmigt"
 
 #: hypha/apply/projects/templates/application_projects/project_list.html:6
-#: hypha/apply/projects/views/project_partials.py:110
-#: hypha/core/navigation.py:77 hypha/core/navigation.py:111
+#: hypha/core/navigation.py:98 hypha/core/navigation.py:133
 msgid "Projects"
 msgstr "Projekte"
 
 #: hypha/apply/projects/templates/application_projects/project_list.html:11
-#: hypha/core/navigation.py:83
+#: hypha/core/navigation.py:104
 msgid "All Projects"
 msgstr "Alle Projekte"
 
@@ -5739,155 +6144,87 @@ msgstr "Alle Projekte"
 msgid "View, Search and filter all projects"
 msgstr "Anzeigen, Suchen und Filtern aller Projekte"
 
-#: hypha/apply/projects/templates/application_projects/project_list.html:27
+#: hypha/apply/projects/templates/application_projects/project_list.html:26
 msgid "No Projects Available."
 msgstr "Keine Projekte verfügbar."
 
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:27
+#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:19
 #: hypha/apply/projects/templates/application_projects/sow_export.html:5
 msgid "Scope of Work"
 msgstr "Arbeitsumfang"
 
-#: hypha/apply/projects/templates/application_projects/project_sow_detail.html:52
-msgid "Download SOW"
-msgstr "Statement of Work herunterladen"
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:3
+msgid "SOW"
+msgstr "SÄEN"
 
-#: hypha/apply/projects/templates/application_projects/project_sow_form.html:60
-msgid "Scope of work form not configured. Please add it in the"
-msgstr ""
-"Formular zum Arbeitsumfang ist nicht konfiguriert. Bitte fügen Sie es ein"
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:10
+msgid "Statement of work"
+msgstr "Statement of Work"
 
-#: hypha/apply/projects/templates/application_projects/report_detail.html:4
-#: hypha/apply/projects/templates/application_projects/report_detail.html:14
-msgid "Report"
-msgstr "Bericht"
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:92
+msgid "The statement of work form has not been set up yet."
+msgstr "Das Statement of Work ist noch nicht erstellt."
 
-#: hypha/apply/projects/templates/application_projects/report_detail.html:23
-#: hypha/apply/projects/templates/application_projects/report_form.html:31
-msgid "This report is for the period"
-msgstr "Dieser Bericht ist für den Zeitraum"
+#: hypha/apply/projects/templates/application_projects/project_sow_form.html:98
+msgid "configure"
+msgstr "konfigurieren"
 
-#: hypha/apply/projects/templates/application_projects/report_detail.html:29
-msgid "Report Skipped"
-msgstr "Bericht übersprungen"
-
-#: hypha/apply/projects/templates/application_projects/report_detail.html:31
-msgid "Public Report"
-msgstr "Öffentlicher Bericht"
-
-#: hypha/apply/projects/templates/application_projects/report_detail.html:69
-msgid "View previous report"
-msgstr "Vorherigen Bericht anzeigen"
-
-#: hypha/apply/projects/templates/application_projects/report_detail.html:76
-msgid "View next report"
-msgstr "Nächsten Bericht anzeigen"
-
-#: hypha/apply/projects/templates/application_projects/report_form.html:8
-msgid "Edit Report"
-msgstr "Bericht bearbeiten"
-
-#: hypha/apply/projects/templates/application_projects/report_form.html:18
-msgid "Submit a report"
-msgstr "Einen Bericht einreichen"
-
-#: hypha/apply/projects/templates/application_projects/report_form.html:56
-msgid ""
-"Saving a draft means this report will be visible to you and staff from your "
-"project page."
-msgstr ""
-"Das Speichern eines Entwurfs bedeutet, dass dieser Bericht für Sie und das "
-"Projektteam auf Ihrer Projektseite sichtbar sein wird."
-
-#: hypha/apply/projects/templates/application_projects/report_form.html:66
-msgid ""
-"Project Report Form not configured. Please add a project report form in the"
-msgstr ""
-"Projektberichtsformular nicht konfiguriert. Bitte fügen Sie ein "
-"Projektberichtsformular im"
-
-#: hypha/apply/projects/templates/application_projects/report_form.html:71
-msgid "Project Report Form not configured yet. Please contact us at "
-msgstr ""
-"Projektberichtformular noch nicht konfiguriert. Bitte kontaktieren Sie uns "
-"unter "
-
-#: hypha/apply/projects/templates/application_projects/report_list.html:11
-msgid "Submitted Reports"
-msgstr "Eingereichte Berichte"
-
-#: hypha/apply/projects/templates/application_projects/report_list.html:13
-msgid "View and filter all Submitted Reports"
-msgstr "Anzeigen und Filtern aller eingereichten Berichte"
-
-#: hypha/apply/projects/templates/application_projects/report_list.html:23
-msgid "No Reports Available."
-msgstr "Keine Berichte verfügbar."
-
-#: hypha/apply/projects/templates/application_projects/reporting.html:13
-msgid "View, Search and filter reporting statuses"
-msgstr "Anzeigen, Suchen und Filtern von Berichtsstatus"
-
-#: hypha/apply/projects/templates/application_projects/reporting.html:23
-msgid "No Projects Currently Reporting."
-msgstr "Derzeit werden keine Projekte gemeldet."
-
-#: hypha/apply/projects/templatetags/invoice_tools.py:111
+#: hypha/apply/projects/templatetags/invoice_tools.py:101
 #, python-brace-format
 msgid "{status} by {user_role}"
 msgstr "{status} durch {user_role}"
 
-#: hypha/apply/projects/templatetags/project_tags.py:43
-#: hypha/apply/projects/templatetags/project_tags.py:48
-#: hypha/apply/projects/templatetags/project_tags.py:54
-#: hypha/apply/projects/templatetags/project_tags.py:58
-#: hypha/apply/projects/templatetags/project_tags.py:176
-#: hypha/apply/projects/templatetags/project_tags.py:188
-#: hypha/apply/projects/templatetags/project_tags.py:198
-#: hypha/apply/projects/templatetags/project_tags.py:217
-#: hypha/apply/projects/templatetags/project_tags.py:222
+#: hypha/apply/projects/templatetags/project_tags.py:104
+#: hypha/apply/projects/templatetags/project_tags.py:109
+#: hypha/apply/projects/templatetags/project_tags.py:115
+#: hypha/apply/projects/templatetags/project_tags.py:119
+#: hypha/apply/projects/templatetags/project_tags.py:237
+#: hypha/apply/projects/templatetags/project_tags.py:249
+#: hypha/apply/projects/templatetags/project_tags.py:259
+#: hypha/apply/projects/templatetags/project_tags.py:278
+#: hypha/apply/projects/templatetags/project_tags.py:283
 msgid "To do"
 msgstr "Zu erledigen"
 
-#: hypha/apply/projects/templatetags/project_tags.py:44
+#: hypha/apply/projects/templatetags/project_tags.py:105
 msgid "Fill in the Project Form"
 msgstr "Füllen Sie das Projektformular aus"
 
-#: hypha/apply/projects/templatetags/project_tags.py:49
+#: hypha/apply/projects/templatetags/project_tags.py:110
 msgid "Move project to next stage"
 msgstr "Projekt in nächste Phase verschieben"
 
-#: hypha/apply/projects/templatetags/project_tags.py:55
+#: hypha/apply/projects/templatetags/project_tags.py:116
 msgid "Resubmit project documents for approval"
 msgstr "Reichen Sie Projektunterlagen zur Genehmigung erneut ein"
 
-#: hypha/apply/projects/templatetags/project_tags.py:59
+#: hypha/apply/projects/templatetags/project_tags.py:120
 msgid "Submit project documents for approval"
 msgstr "Projektunterlagen zur Genehmigung einreichen"
 
-#: hypha/apply/projects/templatetags/project_tags.py:63
-#: hypha/apply/projects/templatetags/project_tags.py:71
-#: hypha/apply/projects/templatetags/project_tags.py:75
-#: hypha/apply/projects/templatetags/project_tags.py:81
-#: hypha/apply/projects/templatetags/project_tags.py:97
-#: hypha/apply/projects/templatetags/project_tags.py:103
-#: hypha/apply/projects/templatetags/project_tags.py:118
-#: hypha/apply/projects/templatetags/project_tags.py:127
-#: hypha/apply/projects/templatetags/project_tags.py:133
-#: hypha/apply/projects/templatetags/project_tags.py:141
-#: hypha/apply/projects/templatetags/project_tags.py:150
-#: hypha/apply/projects/templatetags/project_tags.py:157
+#: hypha/apply/projects/templatetags/project_tags.py:124
+#: hypha/apply/projects/templatetags/project_tags.py:132
+#: hypha/apply/projects/templatetags/project_tags.py:136
+#: hypha/apply/projects/templatetags/project_tags.py:142
+#: hypha/apply/projects/templatetags/project_tags.py:158
 #: hypha/apply/projects/templatetags/project_tags.py:164
-#: hypha/apply/projects/templatetags/project_tags.py:168
-#: hypha/apply/projects/templatetags/project_tags.py:182
-#: hypha/apply/projects/templatetags/project_tags.py:192
-#: hypha/apply/projects/templatetags/project_tags.py:205
+#: hypha/apply/projects/templatetags/project_tags.py:179
+#: hypha/apply/projects/templatetags/project_tags.py:188
+#: hypha/apply/projects/templatetags/project_tags.py:194
+#: hypha/apply/projects/templatetags/project_tags.py:202
 #: hypha/apply/projects/templatetags/project_tags.py:211
+#: hypha/apply/projects/templatetags/project_tags.py:218
+#: hypha/apply/projects/templatetags/project_tags.py:225
+#: hypha/apply/projects/templatetags/project_tags.py:229
+#: hypha/apply/projects/templatetags/project_tags.py:243
+#: hypha/apply/projects/templatetags/project_tags.py:253
+#: hypha/apply/projects/templatetags/project_tags.py:266
+#: hypha/apply/projects/templatetags/project_tags.py:272
 msgid "Waiting for"
 msgstr "Warten auf"
 
-#: hypha/apply/projects/templatetags/project_tags.py:65
-#: hypha/apply/projects/templatetags/project_tags.py:83
+#: hypha/apply/projects/templatetags/project_tags.py:126
+#: hypha/apply/projects/templatetags/project_tags.py:144
 #, python-brace-format
 msgid ""
 "Awaiting project documents to be created and approved by {org_short_name} "
@@ -5898,166 +6235,170 @@ msgstr ""
 "durch {org_short_name}. Bitte prüfen Sie erneut, wenn das Projekt in die "
 "Vertragsphase übergegangen ist."
 
-#: hypha/apply/projects/templatetags/project_tags.py:72
+#: hypha/apply/projects/templatetags/project_tags.py:133
 msgid "Changes requested. Awaiting documents to be resubmitted."
 msgstr "Änderungen angefordert. Warten auf erneute Einreichung der Dokumente."
 
-#: hypha/apply/projects/templatetags/project_tags.py:76
+#: hypha/apply/projects/templatetags/project_tags.py:137
 msgid "Awaiting project form to be created."
 msgstr "Warten auf die Erstellung des Projektformulars."
 
-#: hypha/apply/projects/templatetags/project_tags.py:99
-#: hypha/apply/projects/templatetags/project_tags.py:135
+#: hypha/apply/projects/templatetags/project_tags.py:160
+#: hypha/apply/projects/templatetags/project_tags.py:196
 #, python-brace-format
 msgid "Awaiting approval. Assigned to {approver}"
 msgstr "Warten auf Genehmigung. Zugewiesen an {approver}"
 
-#: hypha/apply/projects/templatetags/project_tags.py:105
-#: hypha/apply/projects/templatetags/project_tags.py:143
+#: hypha/apply/projects/templatetags/project_tags.py:166
+#: hypha/apply/projects/templatetags/project_tags.py:204
 #, python-brace-format
 msgid "Awaiting {reviewer_role} to assign an approver"
 msgstr "Warten auf {reviewer_role}, um einen Genehmigenden zuzuweisen"
 
-#: hypha/apply/projects/templatetags/project_tags.py:119
+#: hypha/apply/projects/templatetags/project_tags.py:180
 msgid "Awaiting project form to be approved"
 msgstr "Warten auf die Genehmigung des Projektformulars"
 
-#: hypha/apply/projects/templatetags/project_tags.py:128
+#: hypha/apply/projects/templatetags/project_tags.py:189
 msgid "Awaiting approval from other approvers teams"
 msgstr "Warten auf Genehmigung von anderem Genehmigungsteams"
 
-#: hypha/apply/projects/templatetags/project_tags.py:151
+#: hypha/apply/projects/templatetags/project_tags.py:212
 msgid "Awaiting project from assigned approvers"
 msgstr "Warten auf Projekt vom zugewiesenen Genehmigenden"
 
-#: hypha/apply/projects/templatetags/project_tags.py:158
+#: hypha/apply/projects/templatetags/project_tags.py:219
 #, python-brace-format
 msgid "Awaiting signed contract from {org_short_name}"
 msgstr "Warten auf unterzeichneten Vertrag von {org_short_name}"
 
-#: hypha/apply/projects/templatetags/project_tags.py:165
+#: hypha/apply/projects/templatetags/project_tags.py:226
 msgid "Awaiting signed contract from Staff/Contracting team"
 msgstr "Warten auf den unterzeichneten Vertrag vom Staff/Vertragsteam"
 
-#: hypha/apply/projects/templatetags/project_tags.py:169
+#: hypha/apply/projects/templatetags/project_tags.py:230
 msgid "Awaiting signed contract from Contracting team"
 msgstr "Warten auf den unterzeichneten Vertrag vom Vertragsteam"
 
-#: hypha/apply/projects/templatetags/project_tags.py:178
+#: hypha/apply/projects/templatetags/project_tags.py:239
 msgid "Awaiting contract documents to be submitted by you."
 msgstr "Warten auf die Einreichung der Vertragsdokumente durch Sie."
 
-#: hypha/apply/projects/templatetags/project_tags.py:183
+#: hypha/apply/projects/templatetags/project_tags.py:244
 msgid "Awaiting countersigned contract from Vendor"
 msgstr "Warten auf gegengezeichneten Vertrag vom Lieferanten"
 
-#: hypha/apply/projects/templatetags/project_tags.py:189
+#: hypha/apply/projects/templatetags/project_tags.py:250
 msgid "Awaiting contract documents submission by you"
 msgstr "Warten auf die Einreichung der Vertragsdokumente durch Sie"
 
-#: hypha/apply/projects/templatetags/project_tags.py:193
+#: hypha/apply/projects/templatetags/project_tags.py:254
 msgid "Awaiting contract documents submission from Vendor"
 msgstr "Warten auf die Einreichung der Vertragsdokumente durch den Lieferanten"
 
-#: hypha/apply/projects/templatetags/project_tags.py:200
+#: hypha/apply/projects/templatetags/project_tags.py:261
 msgid "Review the contract for all relevant details and approve."
 msgstr ""
 "Überprüfen Sie den Vertrag auf alle relevanten Details und genehmigen Sie "
 "ihn."
 
-#: hypha/apply/projects/templatetags/project_tags.py:207
+#: hypha/apply/projects/templatetags/project_tags.py:268
 #, python-brace-format
 msgid "Awaiting contract approval from {org_short_name}"
 msgstr "Warten auf Vertragsgenehmigung von {org_short_name}"
 
-#: hypha/apply/projects/templatetags/project_tags.py:212
+#: hypha/apply/projects/templatetags/project_tags.py:273
 msgid "Awaiting contract approval from Staff"
 msgstr "Warten auf Vertragsgenehmigung durch Staff"
 
-#: hypha/apply/projects/templatetags/project_tags.py:218
+#: hypha/apply/projects/templatetags/project_tags.py:279
 msgid "Add invoices"
 msgstr "Rechnungen hinzufügen"
 
-#: hypha/apply/projects/templatetags/project_tags.py:223
+#: hypha/apply/projects/templatetags/project_tags.py:284
 msgid "Review invoice and take action"
 msgstr "Rechnung überprüfen und Maßnahmen ergreifen"
 
-#: hypha/apply/projects/templatetags/project_tags.py:242
+#: hypha/apply/projects/templatetags/project_tags.py:303
 #, python-brace-format
 msgid "Please download the signed contract uploaded by {org_short_name}"
 msgstr ""
 "Bitte laden Sie den unterzeichneten Vertrag herunter, der von "
 "{org_short_name} hochgeladen wurde"
 
-#: hypha/apply/projects/templatetags/project_tags.py:244
+#: hypha/apply/projects/templatetags/project_tags.py:305
 msgid "Countersign"
 msgstr "Gegenzeichnung"
 
-#: hypha/apply/projects/templatetags/project_tags.py:245
+#: hypha/apply/projects/templatetags/project_tags.py:306
 msgid "Upload it back"
 msgstr "Laden Sie es wieder hoch"
 
-#: hypha/apply/projects/templatetags/project_tags.py:247
+#: hypha/apply/projects/templatetags/project_tags.py:308
 msgid "Please also make sure to upload other required contracting documents"
 msgstr ""
 "Bitte stellen Sie sicher, dass Sie auch andere erforderliche "
 "Vertragsdokumente hochladen"
 
-#: hypha/apply/projects/utils.py:74
+#: hypha/apply/projects/utils.py:85
 msgid "Pending approval"
 msgstr "Ausstehende Genehmigung"
 
-#: hypha/apply/projects/utils.py:78
+#: hypha/apply/projects/utils.py:89
 msgid "Request for change or more information"
 msgstr "Anfrage auf Änderung oder weitere Informationen"
 
-#: hypha/apply/projects/views/payment.py:146
-#: hypha/apply/projects/views/payment.py:370
+#: hypha/apply/projects/views/payment.py:165
+#: hypha/apply/projects/views/payment.py:395
 #, python-brace-format
 msgid "<p>Invoice status updated to: {status}.</p>"
 msgstr "<p>Rechnungsstatus aktualisiert auf: {status}.</p>"
 
-#: hypha/apply/projects/views/payment.py:186
+#: hypha/apply/projects/views/payment.py:208
 msgid "Invoice updated."
 msgstr "Rechnung aktualisiert."
 
-#: hypha/apply/projects/views/payment.py:274
+#: hypha/apply/projects/views/payment.py:298
 msgid "<p>Invoice added.</p>"
 msgstr "<p>Rechnung hinzugefügt.</p>"
 
-#: hypha/apply/projects/views/payment.py:532
+#: hypha/apply/projects/views/payment.py:573
 msgid "Sorry something went wrong"
 msgstr "Entschuldigung, etwas ist schief gelaufen"
 
-#: hypha/apply/projects/views/project.py:263
+#: hypha/apply/projects/views/project.py:265
 msgid "PAF has been submitted for approval"
 msgstr "PAF wurde zur Genehmigung eingereicht"
 
-#: hypha/apply/projects/views/project.py:335
+#: hypha/apply/projects/views/project.py:337
 msgid "Document has been uploaded"
 msgstr "Dokument wurde hochgeladen"
 
-#: hypha/apply/projects/views/project.py:363
+#: hypha/apply/projects/views/project.py:365
 msgid "Document has been removed"
 msgstr "Dokument wurde entfernt"
 
-#: hypha/apply/projects/views/project.py:390
+#: hypha/apply/projects/views/project.py:396
 msgid "Contracting document has been removed"
 msgstr "Das Vertragsdokument wurde entfernt"
 
-#: hypha/apply/projects/views/project.py:437
+#: hypha/apply/projects/views/project.py:443
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: hypha/apply/projects/views/project.py:446
+#: hypha/apply/projects/views/project.py:452
 msgid "Lead has been updated."
 msgstr "Der Lead wurde aktualisiert."
 
-#: hypha/apply/projects/views/project.py:492
+#: hypha/apply/projects/views/project.py:498
 msgid "Title has been updated"
 msgstr "Titel wurde aktualisiert"
 
-#: hypha/apply/projects/views/project.py:613
+#: hypha/apply/projects/views/project.py:534
+msgid "Dates has been updated"
+msgstr "Die Daten wurden aktualisiert"
+
+#: hypha/apply/projects/views/project.py:655
 msgid ""
 "Contractor documents have been approved.  You can receive invoices from "
 "vendor now."
@@ -6065,58 +6406,55 @@ msgstr ""
 "Dokumente des Auftragnehmers wurden genehmigt. Sie können nun Rechnungen vom "
 "Lieferanten erhalten."
 
-#: hypha/apply/projects/views/project.py:679
+#: hypha/apply/projects/views/project.py:721
 msgid "Countersigned contract uploaded"
 msgstr "Gegengezeichneter Vertrag hochgeladen"
 
-#: hypha/apply/projects/views/project.py:682
+#: hypha/apply/projects/views/project.py:724
 msgid "Signed contract uploaded"
 msgstr "Unterschriebener Vertrag hochgeladen"
 
-#: hypha/apply/projects/views/project.py:889
+#: hypha/apply/projects/views/project.py:935
 msgid "Contract documents submitted"
 msgstr "Vertragsdokumente eingereicht"
 
-#: hypha/apply/projects/views/project.py:950
+#: hypha/apply/projects/views/project.py:999
 msgid "Contracting document has been uploaded"
 msgstr "Das Vertragsdokument wurde hochgeladen"
 
-#: hypha/apply/projects/views/project.py:1034
+#: hypha/apply/projects/views/project.py:1083
 #, python-brace-format
-msgid "updated project form status to {paf_status}."
-msgstr "aktualisierte Projektformularstatus auf {paf_status}."
+msgid "Updated project form status to: {paf_status}"
+msgstr "Projektformularstatus aktualisiert zu: {paf_status}"
 
-#: hypha/apply/projects/views/project.py:1108
+#: hypha/apply/projects/views/project.py:1173
 msgid "Project form status has been updated"
 msgstr "Der Status des Projektformulars wurde aktualisiert"
 
-#: hypha/apply/projects/views/project.py:1161
+#: hypha/apply/projects/views/project.py:1226
 msgid "Project form has been approved"
 msgstr "Das Projektformular wurde genehmigt"
 
-#: hypha/apply/projects/views/project.py:1270
+#: hypha/apply/projects/views/project.py:1321
 msgid "Project status has been updated"
 msgstr "Projektstatus wurde aktualisiert"
 
-#: hypha/apply/projects/views/project.py:1563
+#: hypha/apply/projects/views/project.py:1614
 msgid "Project form approvers have been updated"
 msgstr "Genehmigende für das Projektformular wurden aktualisiert"
 
-#: hypha/apply/projects/views/report.py:293
-msgid "Reporting disabled"
-msgstr "Berichterstellung deaktiviert"
-
 #: hypha/apply/review/blocks.py:34
-#: hypha/apply/review/templates/review/review_detail.html:33
+#: hypha/apply/review/templates/review/review_detail.html:44
 msgid "Score"
 msgstr "Punktzahl"
 
 #: hypha/apply/review/models.py:169
-#: hypha/apply/review/templates/review/review_detail.html:29
+#: hypha/apply/review/templates/review/review_detail.html:40
 msgid "Recommendation"
 msgstr "Empfehlung"
 
 #: hypha/apply/review/models.py:178
+#: hypha/apply/review/templates/review/review_detail.html:48
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
@@ -6149,6 +6487,7 @@ msgid "n/a - choose not to answer"
 msgstr "n/a - keine Antwort wählen"
 
 #: hypha/apply/review/options.py:23
+#: hypha/apply/stream_forms/templates/stream_forms/render_checkbox_field.html:11
 msgid "No"
 msgstr "Nein"
 
@@ -6157,6 +6496,7 @@ msgid "Maybe"
 msgstr "Vielleicht"
 
 #: hypha/apply/review/options.py:25
+#: hypha/apply/stream_forms/templates/stream_forms/render_checkbox_field.html:8
 msgid "Yes"
 msgstr "Ja"
 
@@ -6184,12 +6524,16 @@ msgstr "Privat"
 msgid "Reviewers and Staff"
 msgstr "Reviewer und Mitarbeiter"
 
-#: hypha/apply/review/templates/review/includes/review_button.html:8
+#: hypha/apply/review/templates/review/includes/review_button.html:10
 msgid "Add a review"
 msgstr "Eine Bewertung hinzufügen"
 
-#: hypha/apply/review/templates/review/review_confirm_delete.html:16
-#: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:16
+#: hypha/apply/review/templates/review/review_confirm_delete.html:4
+#: hypha/apply/review/templates/review/review_confirm_delete.html:8
+msgid "Deleting"
+msgstr "Löschen"
+
+#: hypha/apply/review/templates/review/review_confirm_delete.html:20
 msgid "Are you sure you want to delete"
 msgstr "Sind Sie sicher, dass Sie löschen möchten"
 
@@ -6197,37 +6541,75 @@ msgstr "Sind Sie sicher, dass Sie löschen möchten"
 msgid "Review for"
 msgstr "Bewertung für"
 
-#: hypha/apply/review/templates/review/review_detail.html:20
+#: hypha/apply/review/templates/review/review_detail.html:11
 msgid "at"
 msgstr "bei"
 
-#: hypha/apply/review/templates/review/review_detail.html:68
-msgid "Review was not against the latest version"
-msgstr "Die Bewertung war nicht gegen die neueste Version"
-
-#: hypha/apply/review/templates/review/review_detail.html:94
-msgid ""
-"An opinion is a replacement for a review. You will no longer be able to "
-"submit a review for this application."
+#: hypha/apply/review/templates/review/review_detail.html:25
+msgid "Review was not against the latest version of the application"
 msgstr ""
-"Eine Meinung ist ein Ersatz für eine Bewertung. Sie können für diesen Antrag "
-"keine Bewertung mehr abgeben."
+"Die Überprüfung war nicht gegen die neueste Version der Anwendung gerichtet"
 
-#: hypha/apply/review/templates/review/review_edit_form.html:29
-#: hypha/apply/review/templates/review/review_form.html:39
+#: hypha/apply/review/templates/review/review_detail.html:29
+msgid "View Changes"
+msgstr "Änderungen anzeigen"
+
+#: hypha/apply/review/templates/review/review_detail.html:66
+msgid "Opinions"
+msgstr "Meinungen"
+
+#: hypha/apply/review/templates/review/review_detail.html:99
+msgid "Your opinions"
+msgstr "Eure Meinungen"
+
+#: hypha/apply/review/templates/review/review_detail.html:102
+msgid ""
+"Note: An opinion is a replacement for a review. You will no longer be able "
+"to submit a review for this application."
+msgstr ""
+"Hinweis: Eine Meinung ersetzt eine Rezension. Sie können für diesen Antrag "
+"keine Überprüfung mehr einreichen."
+
+#: hypha/apply/review/templates/review/review_edit_form.html:30
+#: hypha/apply/review/templates/review/review_form.html:50
 msgid "Score:"
 msgstr "Punktzahl:"
 
-#: hypha/apply/review/templates/review/review_edit_form.html:77
-#: hypha/apply/review/templates/review/review_form.html:78
+#: hypha/apply/review/templates/review/review_edit_form.html:80
+#: hypha/apply/review/templates/review/review_form.html:92
 msgid "Total Score:"
 msgstr "Gesamtpunktzahl:"
 
-#: hypha/apply/review/templates/review/review_form.html:100
+#: hypha/apply/review/templates/review/review_form.html:111
 msgid "You have already posted a review for this submission"
 msgstr "Sie haben bereits eine Bewertung für diese Einreichung abgegeben"
 
-#: hypha/apply/review/templatetags/review_tags.py:58
+#: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:3
+msgid "Delete review opinion"
+msgstr "Löschen der Bewertungsmeinung"
+
+#: hypha/apply/review/templates/review/reviewopinion_confirm_delete.html:5
+#, python-format
+msgid ""
+"Are you sure you want to delete this review opinion by %(user)s? This action "
+"cannot be undone."
+msgstr ""
+"Bist du sicher, dass du diese Bewertung um %(user)s löschen möchtest? Diese "
+"Maßnahme kann nicht rückgängig gemacht werden."
+
+#: hypha/apply/review/templatetags/review_tags.py:15
+msgid "Overall recommendation: Yes"
+msgstr "Gesamtempfehlung: Ja"
+
+#: hypha/apply/review/templatetags/review_tags.py:19
+msgid "Overall recommendation: Maybe"
+msgstr "Gesamtempfehlung: Vielleicht"
+
+#: hypha/apply/review/templatetags/review_tags.py:23
+msgid "Overall recommendation: No"
+msgstr "Gesamtempfehlung: Nein"
+
+#: hypha/apply/review/templatetags/review_tags.py:64
 #, python-brace-format
 msgid "Avg. score: {average}"
 msgstr "Durchschnittspunktzahl: {average}"
@@ -6245,7 +6627,7 @@ msgid "Create Review"
 msgstr "Erstellen Sie eine Bewertung"
 
 #: hypha/apply/stream_forms/blocks.py:114
-#: hypha/apply/stream_forms/blocks.py:216
+#: hypha/apply/stream_forms/blocks.py:217
 msgid "Required"
 msgstr "Erforderlich"
 
@@ -6301,66 +6683,66 @@ msgstr "Zahlenfeld"
 msgid "Checkbox field"
 msgstr "Checkbox Feld"
 
-#: hypha/apply/stream_forms/blocks.py:200
-#: hypha/apply/stream_forms/blocks.py:218
+#: hypha/apply/stream_forms/blocks.py:201
+#: hypha/apply/stream_forms/blocks.py:219
 msgid "Choice"
 msgstr "Auswahl"
 
-#: hypha/apply/stream_forms/blocks.py:206
+#: hypha/apply/stream_forms/blocks.py:207
 msgid "Radio buttons"
 msgstr "Radio buttons"
 
-#: hypha/apply/stream_forms/blocks.py:230
+#: hypha/apply/stream_forms/blocks.py:231
 msgid "Group fields"
 msgstr "Gruppenfelder"
 
-#: hypha/apply/stream_forms/blocks.py:261
+#: hypha/apply/stream_forms/blocks.py:262
 msgid "Dropdown field"
 msgstr "Dropdown-Feld"
 
-#: hypha/apply/stream_forms/blocks.py:271
+#: hypha/apply/stream_forms/blocks.py:272
 msgid "Checkbox"
 msgstr "Checkbox"
 
-#: hypha/apply/stream_forms/blocks.py:277
+#: hypha/apply/stream_forms/blocks.py:278
 msgid "Multiple checkboxes field"
 msgstr "Feld mit mehrfachen Checkboxen"
 
-#: hypha/apply/stream_forms/blocks.py:318
+#: hypha/apply/stream_forms/blocks.py:319
 msgid "Date field"
 msgstr "Datumsfeld"
 
-#: hypha/apply/stream_forms/blocks.py:340
+#: hypha/apply/stream_forms/blocks.py:341
 msgid "Time field"
 msgstr "Zeitfeld"
 
-#: hypha/apply/stream_forms/blocks.py:372
+#: hypha/apply/stream_forms/blocks.py:373
 msgid "Date+time field"
 msgstr "Datum+Uhrzeit-Feld"
 
-#: hypha/apply/stream_forms/blocks.py:404
+#: hypha/apply/stream_forms/blocks.py:405
 msgid "Image field"
 msgstr "Bildfeld"
 
-#: hypha/apply/stream_forms/blocks.py:417
+#: hypha/apply/stream_forms/blocks.py:418
 msgid "Single File field"
 msgstr "Einzelnes Dateifeld"
 
-#: hypha/apply/stream_forms/blocks.py:423
-#: hypha/apply/stream_forms/blocks.py:442
+#: hypha/apply/stream_forms/blocks.py:424
+#: hypha/apply/stream_forms/blocks.py:443
 #, python-brace-format
 msgid "{help_text} Accepted file types are {file_types}"
 msgstr "{help_text} Akzeptierte Dateitypen sind {file_types}"
 
-#: hypha/apply/stream_forms/blocks.py:436
+#: hypha/apply/stream_forms/blocks.py:437
 msgid "Multiple File field"
 msgstr "Feld für mehrere Dateien"
 
-#: hypha/apply/stream_forms/blocks.py:473
+#: hypha/apply/stream_forms/blocks.py:474
 msgid "Section header"
 msgstr "Abschnittsüberschrift"
 
-#: hypha/apply/stream_forms/blocks.py:492
+#: hypha/apply/stream_forms/blocks.py:493
 msgid "Form fields"
 msgstr "Formularfelder"
 
@@ -6380,9 +6762,13 @@ msgstr ""
 "Wir werden Ihr Benutzerkonto mit dem Namen aktualisieren, den Sie hier "
 "angeben."
 
-#: hypha/apply/stream_forms/templates/stream_forms/includes/file_field.html:12
+#: hypha/apply/stream_forms/templates/stream_forms/includes/file_field.html:13
 msgid "uploaded"
 msgstr "hochgeladen"
+
+#: hypha/apply/stream_forms/templates/stream_forms/render_checkbox_field.html:13
+msgid "No selection"
+msgstr "Keine Auswahl"
 
 #: hypha/apply/templates/forms/includes/form_errors.html:6
 msgid ""
@@ -6392,214 +6778,233 @@ msgstr ""
 "Es gab einige Fehler in Ihrem Formular. Bitte korrigieren Sie die unten "
 "hervorgehobenen Felder."
 
-#: hypha/apply/todo/options.py:55
+#: hypha/apply/todo/options.py:59
 #, python-brace-format
 msgid ""
-"{related.user} assigned you a comment on [<span class=\"truncate inline-"
-"block max-w-32 align-bottom \">{related.source.title}</span>]({link} "
-"\"{related.source.title}\"):\n"
-"<span class=\"line-clamp-2 italic align-bottom \">{msg}</span>"
+"<span class=\"text-xs\">{related.source.fund_name} "
+"#{related.source.application_id}</span><br>{related.user} assigned you a "
+"comment: <q class=\"text-fg-muted italic align-bottom\">{msg}</q>"
 msgstr ""
-"{related.user} hat Ihnen einen Kommentar zu [<span class=\"truncate inline-"
-"block max-w-32 align-bottom \">{related.source.title}</span>]({link} "
-"\"{related.source.title}\"): <span class=\"line-clamp-2 italic align-bottom "
-"\">{msg}</span> zugewiesen"
+"<span class=\"text-xs\">{related.source.fund_name} "
+"#{related.source.application_id}</span><br>{related.user} hat dir einen "
+"Kommentar zugewiesen: <q class=\"text-fg-muted italic align-bottom\">{msg}</"
+"q>"
 
-#: hypha/apply/todo/options.py:65
+#: hypha/apply/todo/options.py:69
 #, python-brace-format
 msgid ""
-"A Submission draft [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") is waiting to "
-"be submitted"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>A draft application <span class=\"truncate inline-block max-w-32 "
+"align-bottom \">\"{related.title}\"</span> is waiting to be submitted"
 msgstr ""
-"Ein Einreichungsentwurf [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") wartet auf die "
-"Finalisierung"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Ein Entwurfsantrag <span class=\"truncate inline-block max-w-32 "
+"align-bottom \">\"{related.title}\"</span> wartet auf die Einreichung"
 
-#: hypha/apply/todo/options.py:73
+#: hypha/apply/todo/options.py:77
 #, python-brace-format
 msgid ""
-"Determination draft for submission [<span class=\"truncate inline-block max-"
-"w-32 align-bottom \">{related.submission.title}</span>]({link} "
-"\"{related.submission.title}\") is waiting to be submitted"
+"<span class=\"text-xs\">{related.submission.fund_name} "
+"#{related.submission.application_id}</span><br>Determination draft for "
+"submission <span class=\"truncate inline-block max-w-32 align-"
+"bottom\">\"{related.submission.title}\"</span> is waiting to be submitted"
 msgstr ""
-"Entwurf der Entscheidung zur Einreichung [<span class=\"truncate inline-"
-"block max-w-32 align-bottom \">{related.submission.title}</span>]({link} "
-"\"{related.submission.title}\") wartet auf die Einreichung"
+"<span class=\"text-xs\">{related.submission.fund_name} "
+"#{related.submission.application_id}</span><br>Der Entwurf für die "
+"Einreichung <span class=\"truncate inline-block max-w-32 align-"
+"bottom\">\"{related.submission.title}\"</span> wartet auf die Einreichung"
 
-#: hypha/apply/todo/options.py:81
+#: hypha/apply/todo/options.py:85
 #, python-brace-format
 msgid ""
-"Review draft for submission [<span class=\"truncate inline-block max-w-32 "
-"align-bottom \">{related.submission.title}</span>]({link} "
-"\"{related.submission.title}\") is waiting to be submitted"
+"<span class=\"text-xs\">{related.submission.fund_name} "
+"#{related.submission.application_id}</span><br>Review draft for submission "
+"<span class=\"truncate inline-block max-w-32 align-"
+"bottom\">\"{related.submission.title}\"</span> is waiting to be submitted"
 msgstr ""
-"Überprüfen Sie den Entwurf für die Einreichung [<span class=\"truncate "
-"inline-block max-w-32 align-bottom \">{related.submission.title}</span>]"
-"({link} \"{related.submission.title}\") wartet auf die Einreichung"
+"<span class=\"text-xs\">{related.submission.fund_name} "
+"#{related.submission.application_id}</span><br>Review-Entwurf zur "
+"Einreichung <span class=\"truncate inline-block max-w-32 align-"
+"bottom\">\"{related.submission.title}\"</span> wartet auf die Einreichung"
 
-#: hypha/apply/todo/options.py:91
+#: hypha/apply/todo/options.py:95
 #, python-brace-format
 msgid ""
-"Project [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"project form"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project is waiting for project form"
 msgstr ""
-"Projekt [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") wartet auf "
-"Projektformular"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Projekt wartet auf das Projektformular"
 
-#: hypha/apply/todo/options.py:95 hypha/apply/todo/options.py:103
-#: hypha/apply/todo/options.py:111 hypha/apply/todo/options.py:119
-#: hypha/apply/todo/options.py:128 hypha/apply/todo/options.py:136
-#: hypha/apply/todo/options.py:145 hypha/apply/todo/options.py:153
-#: hypha/apply/todo/options.py:161 hypha/apply/todo/options.py:170
-#: hypha/apply/todo/options.py:178 hypha/apply/todo/options.py:186
-#: hypha/apply/todo/options.py:192 hypha/apply/todo/options.py:200
+#: hypha/apply/todo/options.py:99 hypha/apply/todo/options.py:107
+#: hypha/apply/todo/options.py:115 hypha/apply/todo/options.py:123
+#: hypha/apply/todo/options.py:132 hypha/apply/todo/options.py:140
+#: hypha/apply/todo/options.py:149 hypha/apply/todo/options.py:157
+#: hypha/apply/todo/options.py:165 hypha/apply/todo/options.py:174
+#: hypha/apply/todo/options.py:182 hypha/apply/todo/options.py:190
+#: hypha/apply/todo/options.py:198 hypha/apply/todo/options.py:206
 msgid "project"
 msgstr "Projekt"
 
-#: hypha/apply/todo/options.py:99
+#: hypha/apply/todo/options.py:103
 #, python-brace-format
 msgid ""
-"Project [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") is waiting for scope "
-"of work"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project is waiting for scope of work"
 msgstr ""
-"Projekt [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") wartet auf "
-"Leistungsbeschreibung"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Projekt wartet auf den Arbeitsumfang"
 
-#: hypha/apply/todo/options.py:107
+#: hypha/apply/todo/options.py:111
 #, python-brace-format
 msgid ""
-"Project [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"project form(s) submission"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project is waiting for project form(s) submission"
 msgstr ""
-"Projekt [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") wartet auf die "
-"Einreichung von Projektformularen"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Projekt wartet auf die Einreichung der Projektformulare"
 
-#: hypha/apply/todo/options.py:115
+#: hypha/apply/todo/options.py:119
 #, python-brace-format
 msgid ""
-"Project form for project [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") required "
-"changes or more information"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project form requires changes or more information"
 msgstr ""
-"Projektformular für Projekt [<span class=\"truncate inline-block max-w-32 "
-"align-bottom \">{related.title}</span>]({link} \"{related.title}\") "
-"erforderliche Änderungen oder weitere Informationen"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}Das</"
+"span> <br>Projektformular erfordert Änderungen oder weitere Informationen"
 
-#: hypha/apply/todo/options.py:124
+#: hypha/apply/todo/options.py:128
 #, python-brace-format
 msgid ""
-"Project form for project [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"assignee"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project form is waiting for assignee"
 msgstr ""
-"Projektformular für Projekt [<span class=\"truncate inline-block max-w-32 "
-"align-bottom \">{related.title}</span>]({link} \"{related.title}\") wartet "
-"auf Zuweisung eines Bearbeiters"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Das Projektformular wartet auf den Zugewiesenen"
 
-#: hypha/apply/todo/options.py:132
+#: hypha/apply/todo/options.py:136
 #, python-brace-format
 msgid ""
-"Project form for project [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"your approval"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br> Project form is waiting for your approval"
 msgstr ""
-"Projektformular für Projekt [<span class=\"truncate inline-block max-w-32 "
-"align-bottom \">{related.title}</span>]({link} \"{related.title}\") wartet "
-"auf Ihre Genehmigung"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br> Das Projektformular wartet auf deine Genehmigung"
 
-#: hypha/apply/todo/options.py:141
+#: hypha/apply/todo/options.py:145
 #, python-brace-format
 msgid ""
-"Project [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"contract"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project is waiting for contract"
 msgstr ""
-"Projekt [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") wartet auf Vertrag"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Projekt wartet auf einen Vertrag"
 
-#: hypha/apply/todo/options.py:149
+#: hypha/apply/todo/options.py:153
 #, python-brace-format
 msgid ""
-"Project [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"contracting documents"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project is waiting for contracting documents"
 msgstr ""
-"Projekt [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") wartet auf "
-"Vertragsdokumente"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Projekt wartet auf Vertragsdokumente"
 
-#: hypha/apply/todo/options.py:157
+#: hypha/apply/todo/options.py:161
 #, python-brace-format
 msgid ""
-"Contract for project [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") is waiting for "
-"review"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Contract for project is waiting for review"
 msgstr ""
-"Vertrag für Projekt [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") wartet auf "
-"Bewertung"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Vertrag für das Projekt wartet auf Überprüfung"
 
-#: hypha/apply/todo/options.py:166
+#: hypha/apply/todo/options.py:170
 #, python-brace-format
 msgid ""
-"Project [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") is waiting for invoice"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Project <span class=\"truncate inline-block max-w-32 align-"
+"bottom\">\"{related.title}\"</span> is waiting for invoice"
 msgstr ""
-"Projekt [<span class=\"truncate inline-block max-w-32 align-bottom "
-"\">{related.title}</span>]({link} \"{related.title}\") wartet auf Rechnung"
+"<span class=\"text-xs\">{related.fund_name} #{related.application_id}</"
+"span><br>Projekt <span class=\"truncate inline-block max-w-32 align-"
+"bottom\">\"{related.title}\"</span> wartet auf die Rechnung"
 
-#: hypha/apply/todo/options.py:174
+#: hypha/apply/todo/options.py:178
 #, python-brace-format
 msgid ""
-"Invoice [{related.invoice_number}]({link}) required changes or more "
-"information"
+"<span class='text-xs'>{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Invoice no. "
+"{related.invoice_number} required changes or more information"
 msgstr ""
-"Rechnung [{related.invoice_number}]({link}) erfordert Änderungen oder "
-"weitere Informationen"
+"<span class='text-xs'>{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Invoice no. "
+"{related.invoice_number} erforderliche Änderungen oder weitere Informationen"
 
-#: hypha/apply/todo/options.py:182
-#, python-brace-format
-msgid "Invoice [{related.invoice_number}]({link}) is waiting for your approval"
-msgstr ""
-"Rechnung [{related.invoice_number}]({link}) wartet auf Ihre Genehmigung"
-
-#: hypha/apply/todo/options.py:189
-#, python-brace-format
-msgid "Invoice [{related.invoice_number}]({link}) is waiting to be paid"
-msgstr "Rechnung [{related.invoice_number}]({link}) wartet auf Zahlung"
-
-#: hypha/apply/todo/options.py:196
+#: hypha/apply/todo/options.py:186
 #, python-brace-format
 msgid ""
-"Report for project [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") is due"
+"<span class='text-xs'>{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Invoice no. "
+"{related.invoice_number} is waiting for your approval"
 msgstr ""
-"Bericht für Projekt [<span class=\"truncate inline-block max-w-32 align-"
-"bottom \">{related.title}</span>]({link} \"{related.title}\") ist fällig"
+"<span class='text-xs'>{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Invoice no. "
+"{related.invoice_number} wartet auf deine Zustimmung"
+
+#: hypha/apply/todo/options.py:194
+#, python-brace-format
+msgid ""
+"<span class='text-xs'>{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Invoice no. "
+"{related.invoice_number} is waiting to be paid"
+msgstr ""
+"<span class='text-xs'>{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Invoice no. "
+"{related.invoice_number} wartet darauf, bezahlt zu werden"
+
+#: hypha/apply/todo/options.py:202
+#, python-brace-format
+msgid ""
+"<span class=\"text-xs\">{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Report for project <span "
+"class=\"truncate inline-block max-w-32 align-bottom "
+"\">\"{related.project.title}\"</span> is due"
+msgstr ""
+"<span class=\"text-xs\">{related.project.fund_name} "
+"#{related.project.application_id}</span><br>Report for project <span "
+"class=\"truncate inline-block max-w-32 align-bottom "
+"\">\"{related.project.title}\"</span> ist fällig"
+
+#: hypha/apply/todo/options.py:210
+msgid "Your generated submission export file is ready for download"
+msgstr "Ihre generierte Einsendungs-Exportdatei ist zum Download bereit"
+
+#: hypha/apply/todo/options.py:213 hypha/apply/todo/options.py:221
+msgid "export"
+msgstr "exportieren"
+
+#: hypha/apply/todo/options.py:217
+msgid ""
+"There was an issue generating your submission export file, please try again."
+msgstr ""
+"Es gab ein Problem bei der Erstellung deiner Einsendungs-Exportdatei, bitte "
+"versuchen Sie es erneut."
 
 #: hypha/apply/todo/templates/todo/todolist_dropdown.html:7
-msgid "No pending task."
-msgstr "Keine ausstehende Aufgabe."
+msgid "You don't have any pending task."
+msgstr "Du hast keine offene Aufgabe."
 
-#: hypha/apply/todo/templates/todo/todolist_item.html:18
-#: hypha/apply/todo/templates/todo/todolist_item.html:25
-msgid "Remove this task"
-msgstr "Diese Aufgabe löschen"
+#: hypha/apply/todo/templates/todo/todolist_item.html:37
+msgid "Remove from your task list"
+msgstr "Aus deiner Aufgabenliste entfernen"
 
-#: hypha/apply/todo/templates/todo/todolist_item.html:22
+#: hypha/apply/todo/templates/todo/todolist_item.html:42
 msgid ""
-"Are you sure you want to remove this task? It will remove this task from "
-"your task list."
+"Are you sure you want to remove this task from your task list? This can not "
+"be undone."
 msgstr ""
-"Sind Sie sicher, dass Sie diese Aufgabe entfernen möchten? Sie wird damit "
-"aus Ihrer Aufgabenliste entfernen."
+"Bist du sicher, dass du diese Aufgabe aus deiner Aufgabenliste streichen "
+"möchtest? Das lässt sich nicht rückgängig machen."
 
 #: hypha/apply/users/forms.py:27 hypha/apply/users/forms.py:63
 msgid "Remember me"
@@ -6636,7 +7041,7 @@ msgid "Only includes active, non-superusers"
 msgstr "Nur aktive, keine Superuser"
 
 #: hypha/apply/users/forms.py:252
-#: hypha/apply/users/templates/users/account.html:59
+#: hypha/apply/users/templates/users/account.html:64
 #: hypha/apply/users/templates/users/activation/email.txt:13
 msgid "Password"
 msgstr "Passwort"
@@ -6794,17 +7199,17 @@ msgstr ""
 msgid "Confirm access"
 msgstr "Zugriff bestätigen"
 
-#: hypha/apply/users/templates/elevate/elevate.html:45
-#: hypha/apply/users/templates/elevate/elevate.html:61
+#: hypha/apply/users/templates/elevate/elevate.html:42
+#: hypha/apply/users/templates/elevate/elevate.html:59
 msgid "Send a confirmation code to your email"
 msgstr "Senden Sie einen Bestätigungscode an Ihre E-Mail"
 
-#: hypha/apply/users/templates/elevate/elevate.html:52
+#: hypha/apply/users/templates/elevate/elevate.html:50
 #: hypha/apply/users/templates/users/partials/confirmation_code_sent.html:59
 msgid "Having problems?"
 msgstr "Haben Sie Probleme?"
 
-#: hypha/apply/users/templates/elevate/elevate.html:72
+#: hypha/apply/users/templates/elevate/elevate.html:70
 msgid ""
 "\n"
 "                <strong>Tip:</strong> You are entering sudo mode. After "
@@ -6819,24 +7224,33 @@ msgstr ""
 "der Inaktivität wieder aufgefordert, sich erneut zu authentifizieren. "
 
 #: hypha/apply/users/templates/two_factor/_base.html:8
-msgid "Back to Account"
+#: hypha/apply/users/templates/users/change_password.html:9
+msgid "Back to account"
 msgstr "Zurück zum Konto"
 
-#: hypha/apply/users/templates/two_factor/_base.html:12
-#: hypha/apply/users/templates/users/account.html:77
+#: hypha/apply/users/templates/two_factor/_base.html:9
+#: hypha/apply/users/templates/users/account.html:85
 msgid "Two-Factor Authentication (2FA)"
 msgstr "Zwei-Faktor-Authentifizierung (2FA)"
 
-#: hypha/apply/users/templates/two_factor/_base.html:20
-#: hypha/apply/users/templates/users/account.html:15
+#: hypha/apply/users/templates/two_factor/_base.html:14
+#: hypha/apply/users/templates/users/account.html:16
 msgid "Go to my dashboard"
 msgstr "Gehe zu meinem Dashboard"
+
+#: hypha/apply/users/templates/two_factor/_wizard_actions.html:6
+#: hypha/apply/users/templates/two_factor/_wizard_actions.html:10
+#: hypha/apply/users/templates/two_factor/core/backup_tokens_password.html:39
+#: hypha/apply/users/templates/users/passwordless_login_signup.html:47
+#: hypha/templates/cotton/pagination.html:22
+msgid "Next"
+msgstr "Weiter"
 
 #: hypha/apply/users/templates/two_factor/_wizard_actions.html:8
 msgid "I've installed a 2FA App"
 msgstr "Ich habe eine 2FA-App installiert"
 
-#: hypha/apply/users/templates/two_factor/_wizard_actions.html:24
+#: hypha/apply/users/templates/two_factor/_wizard_actions.html:19
 msgid "Verification code"
 msgstr "Verifizierungscode"
 
@@ -6851,12 +7265,12 @@ msgstr ""
 "Sind Sie sicher, dass Sie die Zwei-Faktor-Authentifizierung für diesen "
 "Benutzer deaktivieren möchten?"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:5
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:6
 #: hypha/apply/users/templates/two_factor/core/backup_tokens_password.html:5
 msgid "Backup Codes"
 msgstr "Backup Code"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:8
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:10
 msgid ""
 "You should now print these codes or copy them to your\n"
 "            clipboard and store them in your password manager."
@@ -6864,23 +7278,23 @@ msgstr ""
 "Sie sollten diese Codes jetzt ausdrucken oder in die Zwischenablage kopieren "
 "und in Ihrem Passwort-Manager speichern."
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:22
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:28
 msgid "Print"
 msgstr "Drucken"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:27
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:35
 msgid "Copied!"
 msgstr "Kopiert!"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:29
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:39
 msgid "Copy to Clipboard"
 msgstr "In die Zwischenablage kopieren"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:30
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:41
 msgid "Regenerate Codes"
 msgstr "Regeneriere Codes"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:33
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:45
 msgid ""
 "<strong>Note:</strong> Each of the code can be used only once. When they are "
 "used up, you can generate a new set of backup codes."
@@ -6889,7 +7303,7 @@ msgstr ""
 "sie aufgebraucht sind, können Sie einen neuen Satz von Backup-Codes "
 "generieren."
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:34
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:48
 msgid ""
 "Once done, acknowledge you have stored the codes securely and then click "
 "\"Finish\"."
@@ -6897,15 +7311,15 @@ msgstr ""
 "Sobald Sie fertig sind, bestätigen Sie, dass Sie die Codes sicher "
 "gespeichert haben und klicken Sie dann auf \"Fertig\"."
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:42
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:63
 msgid "Finish"
 msgstr "Fertigstellen"
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:48
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:69
 msgid "You don't have any backup codes yet."
 msgstr "Sie haben noch keine Backup-Codes."
 
-#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:50
+#: hypha/apply/users/templates/two_factor/core/backup_tokens.html:72
 msgid "Generate Codes"
 msgstr "Codes generieren"
 
@@ -6931,13 +7345,12 @@ msgstr ""
 #: hypha/apply/users/templates/two_factor/profile/disable.html:21
 #: hypha/apply/users/templates/users/change_password.html:31
 #: hypha/apply/users/templates/users/password_reset/confirm.html:30
-#: hypha/apply/users/templates/users/password_reset/form.html:28
 msgid "<li>Please correct the error below.</li>"
 msgid_plural "<li>Please correct the errors below.</li>"
-msgstr[0] "<li>Bitte korrigieren Sie den folgenden Fehler.</li>"
-msgstr[1] "<li>Bitte korrigieren Sie die folgenden Fehler.</li>"
+msgstr[0] "<li>Bitte korrigieren Sie den untenstehenden Fehler.</li>"
+msgstr[1] "<li>Bitte korrigieren Sie die untenstehenden Fehler.</li>"
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:6
+#: hypha/apply/users/templates/two_factor/core/setup.html:7
 msgid ""
 "2FA is an extra layer of security used to make sure that people trying to "
 "gain access to an online account are who they say they are. We recommend "
@@ -6948,7 +7361,7 @@ msgstr ""
 "zuzugreifen, wirklich diejenigen sind, die sie zu sein behaupten. Wir "
 "empfehlen die Verwendung von Authy oder einer anderen Authentifizierungs-App."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:9
+#: hypha/apply/users/templates/two_factor/core/setup.html:10
 #, python-format
 msgid ""
 "Please contact %(ORG_EMAIL)s if you have technical difficulty enabling 2FA."
@@ -6956,31 +7369,31 @@ msgstr ""
 "Bitte kontaktieren Sie %(ORG_EMAIL)s, wenn Sie technische Schwierigkeiten "
 "beim Aktivieren der Zwei-Faktor-Authentifizierung haben."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:12
+#: hypha/apply/users/templates/two_factor/core/setup.html:13
 msgid "Please select which authentication method you would like to use."
 msgstr ""
 "Bitte wählen Sie die Authentifizierungsmethode, die Sie verwenden möchten."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:15
+#: hypha/apply/users/templates/two_factor/core/setup.html:16
 msgid ""
 "2FA requires a verification code to pair your smartphone with your account."
 msgstr ""
 "2FA erfordert einen Verifizierungscode, um Ihr Smartphone mit Ihrem Konto zu "
 "verbinden."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:17
+#: hypha/apply/users/templates/two_factor/core/setup.html:18
 msgid ""
-"<strong>Step 1:</strong> Open the Authencator app on your phone and scan the "
-"QR code displayed below."
+"<strong>Step 1:</strong> Open the Authenticator app on your phone and scan "
+"the QR code displayed below."
 msgstr ""
-"<strong>Schritt 1:</strong> Öffnen Sie die Authentikator-App auf Ihrem "
-"Telefon und scannen Sie den unten angezeigten QR-Code."
+"<strong>Schritt 1:</strong> Öffnen Sie die Authenticator-App auf Ihrem Handy "
+"und scannen Sie den unten angezeigten QR-Code."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:20
+#: hypha/apply/users/templates/two_factor/core/setup.html:21
 msgid "Unable to scan the QR code? Try this link:"
 msgstr "Können Sie den QR-Code nicht scannen? Versuchen Sie diesen Link:"
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:21
+#: hypha/apply/users/templates/two_factor/core/setup.html:22
 msgid ""
 "<strong>Step 2:</strong> Enter the 6-digit verification code generated by "
 "the app below."
@@ -6988,7 +7401,7 @@ msgstr ""
 "<strong>Schritt 2:</strong> Geben Sie den 6-stelligen Verifizierungscode, "
 "der von der App generiert wurde, unten ein."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:23
+#: hypha/apply/users/templates/two_factor/core/setup.html:24
 msgid ""
 "Please enter the phone number you wish to receive the text messages on. This "
 "number will be validated in the next step."
@@ -6996,7 +7409,7 @@ msgstr ""
 "Bitte geben Sie die Telefonnummer ein, auf die Sie die Textnachrichten "
 "erhalten möchten. Diese Nummer wird im nächsten Schritt überprüft."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:27
+#: hypha/apply/users/templates/two_factor/core/setup.html:28
 msgid ""
 "Please enter the phone number you wish to be called on. This number will be "
 "validated in the next step."
@@ -7004,21 +7417,21 @@ msgstr ""
 "Bitte geben Sie die Telefonnummer ein, unter der Sie angerufen werden "
 "möchten. Diese Nummer wird im nächsten Schritt überprüft."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:32
-#: hypha/apply/users/templates/users/login.html:14
+#: hypha/apply/users/templates/two_factor/core/setup.html:33
+#: hypha/apply/users/templates/users/login.html:13
 msgid "We are calling your phone right now, please enter the digits you hear."
 msgstr ""
 "Wir rufen Sie gerade auf Ihrem Telefon an, bitte geben Sie die Ziffern ein, "
 "die Sie hören."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:35
-#: hypha/apply/users/templates/users/login.html:17
+#: hypha/apply/users/templates/two_factor/core/setup.html:36
+#: hypha/apply/users/templates/users/login.html:16
 msgid "We sent you a text message, please enter the tokens we sent."
 msgstr ""
 "Wir haben Ihnen eine SMS geschickt, geben Sie bitte die Token ein, die wir "
 "Ihnen geschickt haben."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:39
+#: hypha/apply/users/templates/two_factor/core/setup.html:40
 msgid ""
 "We've encountered an issue with the selected authentication method. Please "
 "go back and verify that you entered your information correctly, try again, "
@@ -7031,7 +7444,7 @@ msgstr ""
 "verwenden Sie stattdessen eine andere Authentifizierungsmethode. Wenn das "
 "Problem weiterhin besteht, kontaktieren Sie den Administrator."
 
-#: hypha/apply/users/templates/two_factor/core/setup.html:46
+#: hypha/apply/users/templates/two_factor/core/setup.html:47
 msgid ""
 "To identify and verify your YubiKey, please insert a token in the field "
 "below. Your YubiKey will be linked to your account."
@@ -7053,12 +7466,7 @@ msgstr ""
 "Wir empfehlen Ihnen dringend, die Backup-Codes zu speichern. Um die Backup-"
 "Codes zu erhalten, können Sie mit \"Codes anzeigen\" fortfahren."
 
-#: hypha/apply/users/templates/two_factor/core/setup_complete.html:15
-#: hypha/apply/users/templates/two_factor/core/setup_complete.html:22
-msgid "Show Codes"
-msgstr "Zeige Codes"
-
-#: hypha/apply/users/templates/two_factor/core/setup_complete.html:18
+#: hypha/apply/users/templates/two_factor/core/setup_complete.html:14
 msgid ""
 "However, it might happen that you don't have access to your primary token "
 "device. To enable account recovery, add a phone number."
@@ -7067,7 +7475,12 @@ msgstr ""
 "Gerät haben. Um die Konto-Wiederherstellung zu ermöglichen, fügen Sie eine "
 "Telefonnummer hinzu."
 
-#: hypha/apply/users/templates/two_factor/core/setup_complete.html:26
+#: hypha/apply/users/templates/two_factor/core/setup_complete.html:20
+#: hypha/apply/users/templates/two_factor/core/setup_complete.html:30
+msgid "Show Codes"
+msgstr "Zeige Codes"
+
+#: hypha/apply/users/templates/two_factor/core/setup_complete.html:24
 msgid "Add Phone Number"
 msgstr "Telefonnummer hinzufügen"
 
@@ -7124,41 +7537,37 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: hypha/apply/users/templates/users/account.html:9
+#: hypha/apply/users/templates/users/account.html:10
 msgid "Manage your account details and security."
 msgstr "Verwalten Sie Ihre Kontodaten und Sicherheit."
 
-#: hypha/apply/users/templates/users/account.html:40
+#: hypha/apply/users/templates/users/account.html:46
 msgid "Profile"
 msgstr "Profil"
 
-#: hypha/apply/users/templates/users/account.html:48
-msgid "Update Profile"
-msgstr "Profil aktualisieren"
-
-#: hypha/apply/users/templates/users/account.html:55
+#: hypha/apply/users/templates/users/account.html:60
 msgid "Account Security"
 msgstr "Kontosicherheit"
 
-#: hypha/apply/users/templates/users/account.html:63
+#: hypha/apply/users/templates/users/account.html:69
 #: hypha/apply/users/templates/users/change_password.html:3
 msgid "Update password"
 msgstr "Passwort aktualisieren"
 
-#: hypha/apply/users/templates/users/account.html:70
+#: hypha/apply/users/templates/users/account.html:77
 msgid "Set Password"
 msgstr "Passwort festlegen"
 
-#: hypha/apply/users/templates/users/account.html:80
+#: hypha/apply/users/templates/users/account.html:89
 msgid "Backup codes"
 msgstr "Backup Code"
 
-#: hypha/apply/users/templates/users/account.html:81
+#: hypha/apply/users/templates/users/account.html:90
 #: hypha/apply/users/templates/wagtailusers/users/edit.html:77
 msgid "Disable 2FA"
 msgstr "2FA deaktivieren"
 
-#: hypha/apply/users/templates/users/account.html:83
+#: hypha/apply/users/templates/users/account.html:92
 msgid "Enable 2FA"
 msgstr "Zweifaktor-Authentifizierung aktivieren"
 
@@ -7209,54 +7618,36 @@ msgstr ""
 "Wenn Sie den Aktivierungsprozess nicht innerhalb von %(timeout_days)s Tagen "
 "abschließen, können Sie das Formular zum Zurücksetzen des Passworts unter"
 
-#: hypha/apply/users/templates/users/activation/email.txt:17
-#: hypha/apply/users/templates/users/email_change/confirm_email.txt:10
-#: hypha/apply/users/templates/users/emails/confirm_access.md:14
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:21
-#: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:11
-#: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:16
-#: hypha/apply/users/templates/users/emails/set_password.txt:10
-#: hypha/apply/users/templates/users/password_reset/email.txt:10
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"The %(org_short_name)s Team"
-msgstr "Mit freundlichen Grüßen, Das %(org_short_name)s-Team"
-
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
 msgid "Account details for %(username)s at %(org_long_name)s"
 msgstr "Kontodetails für %(username)s bei %(org_long_name)s"
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
-msgid "Invalid activation"
-msgstr "Ungültige Aktivierung"
+msgid "Activation link issue"
+msgstr "Problem mit der Aktivierungsverbindung"
 
-#: hypha/apply/users/templates/users/activation/invalid.html:13
-msgid "Invalid activation URL"
-msgstr "Ungültige Aktivierungs-URL"
+#: hypha/apply/users/templates/users/activation/invalid.html:15
+msgid "We couldn't activate your account"
+msgstr "Wir konnten Ihr Konto nicht aktivieren"
 
-#: hypha/apply/users/templates/users/activation/invalid.html:16
-msgid "Two possible reasons:"
-msgstr "Zwei mögliche Gründe:"
+#: hypha/apply/users/templates/users/activation/invalid.html:20
+msgid ""
+"This usually happens because your activation link has expired, or your "
+"account is already activated."
+msgstr ""
+"Das passiert meist, weil dein Aktivierungslink abgelaufen ist oder dein "
+"Konto bereits aktiviert ist."
 
-#: hypha/apply/users/templates/users/activation/invalid.html:18
-msgid "The activation link has expired."
-msgstr "Der Aktivierungslink ist abgelaufen."
-
-#: hypha/apply/users/templates/users/activation/invalid.html:19
-msgid "The account has already been activated."
-msgstr "Das Konto wurde bereits aktiviert."
-
-#: hypha/apply/users/templates/users/activation/invalid.html:22
+#: hypha/apply/users/templates/users/activation/invalid.html:23
 #, python-format
 msgid ""
-"First try to <a href=\"%(password_reset)s\">reset your password</a>. If that "
-"fails please contact %(ORG_SHORT_NAME)s at"
+"Try <a href=\"%(password_reset)s\">resetting your password</a> first. If "
+"you're still having trouble, contact us at %(ORG_SHORT_NAME)s:"
 msgstr ""
-"Zuerst versuchen Sie, Ihr Passwort <a "
-"href=\"%(password_reset)s\">zurückzusetzen</a>. Wenn das fehlschlägt, wenden "
-"Sie sich bitte an %(ORG_SHORT_NAME)s bei"
+"Versuche <a href=\"%(password_reset)s\"> zuerst dein Passwort "
+"zurückzusetzen</a>. Wenn Sie weiterhin Probleme haben, kontaktieren Sie uns "
+"unter %(ORG_SHORT_NAME)s:"
 
 #: hypha/apply/users/templates/users/become.html:3
 msgid "Switch to User..."
@@ -7271,13 +7662,9 @@ msgstr "Benutzer auswählen:"
 msgid "Switch User"
 msgstr "Benutzer wechseln"
 
-#: hypha/apply/users/templates/users/change_password.html:8
+#: hypha/apply/users/templates/users/change_password.html:10
 msgid "Change Password"
 msgstr "Passwort ändern"
-
-#: hypha/apply/users/templates/users/change_password.html:11
-msgid "Back to account"
-msgstr "Zurück zum Konto"
 
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
@@ -7309,19 +7696,19 @@ msgstr "E-Mail-Änderung - E-Mail verifizieren"
 msgid "Verify Email"
 msgstr "E-Mail verifizieren"
 
-#: hypha/apply/users/templates/users/email_change/done.html:9
+#: hypha/apply/users/templates/users/email_change/done.html:8
 msgid "Email Update"
 msgstr "E-Mail-Update"
 
-#: hypha/apply/users/templates/users/email_change/done.html:13
+#: hypha/apply/users/templates/users/email_change/done.html:14
 msgid "Confirm &amp; verify your new email!"
 msgstr "Bestätigen und überprüfen Sie Ihre neue E-Mail!"
 
-#: hypha/apply/users/templates/users/email_change/done.html:15
+#: hypha/apply/users/templates/users/email_change/done.html:16
 msgid "We have sent a confirmation link to your new email."
 msgstr "Wir haben einen Bestätigungslink an Ihre neue E-Mail-Adresse gesendet."
 
-#: hypha/apply/users/templates/users/email_change/done.html:18
+#: hypha/apply/users/templates/users/email_change/done.html:19
 msgid ""
 "To start using the new email, please click on the confirmation link that has "
 "been sent to you on your new email."
@@ -7333,19 +7720,17 @@ msgstr ""
 msgid "Invalid Confirmation"
 msgstr "Ungültige Bestätigung"
 
-#: hypha/apply/users/templates/users/email_change/invalid_link.html:5
+#: hypha/apply/users/templates/users/email_change/invalid_link.html:15
 msgid "Invalid Confirmation URL"
 msgstr "Ungültige Bestätigungs-URL"
 
-#: hypha/apply/users/templates/users/email_change/invalid_link.html:9
-msgid "Possible reason:"
-msgstr "Möglicher Grund:"
+#: hypha/apply/users/templates/users/email_change/invalid_link.html:18
+msgid "The confirmation link you used is either invalid or has expired."
+msgstr ""
+"Der von Ihnen verwendete Bestätigungslink ist entweder ungültig oder "
+"abgelaufen."
 
-#: hypha/apply/users/templates/users/email_change/invalid_link.html:11
-msgid "The confirmation link has expired."
-msgstr "Der Bestätigungslink ist abgelaufen."
-
-#: hypha/apply/users/templates/users/email_change/invalid_link.html:14
+#: hypha/apply/users/templates/users/email_change/invalid_link.html:20
 #, python-format
 msgid ""
 "Try again to change email from accounts page. If that fails please contact "
@@ -7365,79 +7750,6 @@ msgstr ""
 "%(org_long_name)s-Website zu ändern. Wenn Sie diese Aktion nicht selbst "
 "durchgeführt haben, kontaktieren Sie bitte den Support unter %(org_email)s "
 
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"    The %(org_short_name)s Team"
-msgstr "Mit freundlichen Grüßen,     Das %(org_short_name)s-Team"
-
-#: hypha/apply/users/templates/users/emails/confirm_access.md:4
-#, python-format
-msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
-"%(timeout_minutes)s minutes):"
-msgstr ""
-
-#: hypha/apply/users/templates/users/emails/confirm_access.md:8
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:15
-#: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:10
-msgid "If you did not request this email, please ignore it."
-msgstr ""
-"Wenn Sie diese E-Mail nicht angefordert haben, ignorieren Sie sie bitte."
-
-#: hypha/apply/users/templates/users/emails/confirm_access.md:11
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:18
-#: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:8
-#: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
-msgid "If you have any questions, please contact us at %(org_email)s."
-msgstr "Wenn Sie Fragen haben, kontaktieren Sie uns bitte unter %(ors_emails)s."
-
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
-#, python-format
-msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
-"link or copying and pasting it to your browser:"
-msgstr ""
-"Melden Sie sich bei Ihrem Konto auf der %(org_long_name)s-Website an, indem "
-"Sie auf diesen Link klicken oder ihn kopieren und in Ihren Browser einfügen:"
-
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:9
-#: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:8
-#, python-format
-msgid ""
-"This link will valid for %(timeout_minutes)s minutes and can be used only "
-"once."
-msgstr ""
-"Dieser Link ist %(timeout_minutes)s Minuten lang gültig und kann nur einmal "
-"verwendet werden."
-
-#: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
-#, python-format
-msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
-"contact site administrators."
-msgstr ""
-
-#: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:3
-#: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:2
-msgid "Dear,"
-msgstr "Sehr geehrte(r),"
-
-#: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
-#, python-format
-msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
-"could not find any account with the email provided."
-msgstr ""
-
-#: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
-#, python-format
-msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
-"link or copying and pasting it to your browser:"
-msgstr ""
-
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, python-format
 msgid ""
@@ -7453,12 +7765,12 @@ msgstr ""
 msgid "Set password for %(username)s at %(org_long_name)s"
 msgstr "Setzen Sie das Passwort für %(username)s bei %(org_long_name)s"
 
-#: hypha/apply/users/templates/users/login.html:20
-#: hypha/apply/users/templates/users/login.html:24
+#: hypha/apply/users/templates/users/login.html:19
+#: hypha/apply/users/templates/users/login.html:23
 msgid "Two factor verification"
 msgstr "Zweifaktor-Verifizierung"
 
-#: hypha/apply/users/templates/users/login.html:21
+#: hypha/apply/users/templates/users/login.html:20
 msgid ""
 "Please enter the 6-digit verification code generated by your Authenticator "
 "App."
@@ -7466,13 +7778,13 @@ msgstr ""
 "Bitte geben Sie den 6-stelligen Verifizierungscode ein, der von Ihrer "
 "Authenticator-App generiert wurde."
 
-#: hypha/apply/users/templates/users/login.html:26
+#: hypha/apply/users/templates/users/login.html:25
 msgid "Please enter one of the backup codes to log in to your account."
 msgstr ""
 "Bitte geben Sie einen der Sicherungscodes ein, um sich in Ihr Konto "
 "einzuloggen."
 
-#: hypha/apply/users/templates/users/login.html:29
+#: hypha/apply/users/templates/users/login.html:28
 msgid ""
 "Those codes were generated for you during 2FA setup to print or keep safe in "
 "a password manager."
@@ -7480,39 +7792,38 @@ msgstr ""
 "Diese Codes wurden für Sie während der 2FA-Einrichtung generiert, um sie "
 "auszudrucken oder sicher in einem Passwort-Manager aufzubewahren."
 
-#: hypha/apply/users/templates/users/login.html:45
+#: hypha/apply/users/templates/users/login.html:44
 #: hypha/apply/users/templates/users/passwordless_login_signup.html:23
 #, python-format
 msgid "Log in to %(ORG_SHORT_NAME)s"
 msgstr "Melden Sie sich beim %(ORG_SHORT_NAME)s an"
 
-#: hypha/apply/users/templates/users/login.html:51
+#: hypha/apply/users/templates/users/login.html:55
 msgid "Forgot your password?"
 msgstr "Haben Sie Ihr Passwort vergessen?"
 
-#: hypha/apply/users/templates/users/login.html:69
-#: hypha/apply/users/templates/users/passwordless_login_signup.html:5
-#: hypha/apply/users/templates/users/passwordless_login_signup.html:52
-msgid "or"
-msgstr "oder"
+#: hypha/apply/users/templates/users/login.html:74
+#: hypha/apply/users/templates/users/passwordless_login_signup.html:50
+msgid "OR"
+msgstr "ODER"
 
-#: hypha/apply/users/templates/users/login.html:89
+#: hypha/apply/users/templates/users/login.html:93
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Oder alternativ können Sie eines Ihrer Ersatztelefone verwenden:"
 
-#: hypha/apply/users/templates/users/login.html:104
+#: hypha/apply/users/templates/users/login.html:109
 msgid "As a last resort, you can use a backup codes: "
 msgstr "Als letztes Mittel können Sie Backup-Codes verwenden: "
 
-#: hypha/apply/users/templates/users/login.html:112
+#: hypha/apply/users/templates/users/login.html:117
 msgid "Use a Backup Code"
 msgstr "Verwenden Sie einen Backup Code"
 
-#: hypha/apply/users/templates/users/login.html:126
+#: hypha/apply/users/templates/users/login.html:131
 msgid "Verification Code"
 msgstr "Verifizierungscode"
 
-#: hypha/apply/users/templates/users/login.html:130
+#: hypha/apply/users/templates/users/login.html:135
 msgid "Backup Code"
 msgstr "Backup Code"
 
@@ -7594,7 +7905,7 @@ msgstr "Versuchen Sie es erneut"
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
 
-#: hypha/apply/users/templates/users/password_reset/complete.html:8
+#: hypha/apply/users/templates/users/password_reset/complete.html:7
 msgid "Password change successful"
 msgstr "Passwortänderung erfolgreich"
 
@@ -7648,11 +7959,11 @@ msgstr ""
 msgid "Please follow the link below to reset your password:"
 msgstr "Bitte folgen Sie dem Link unten, um Ihr Passwort zurückzusetzen:"
 
-#: hypha/apply/users/templates/users/password_reset/form.html:11
+#: hypha/apply/users/templates/users/password_reset/form.html:12
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: hypha/apply/users/templates/users/password_reset/form.html:12
+#: hypha/apply/users/templates/users/password_reset/form.html:14
 msgid ""
 "Please enter your user account's email address and we will send you a "
 "password reset link."
@@ -7660,9 +7971,13 @@ msgstr ""
 "Bitte geben Sie die E-Mail-Adresse Ihres Benutzerkontos ein und wir senden "
 "Ihnen einen Link zum Zurücksetzen des Passworts."
 
-#: hypha/apply/users/templates/users/password_reset/form.html:39
+#: hypha/apply/users/templates/users/password_reset/form.html:26
 msgid "Send reset email"
 msgstr "Sende Zurücksetzungs-E-Mail"
+
+#: hypha/apply/users/templates/users/passwordless_login_signup.html:5
+msgid "or"
+msgstr "oder"
 
 #: hypha/apply/users/templates/users/passwordless_login_signup.html:5
 msgid "Sign up"
@@ -7738,6 +8053,7 @@ msgstr "Inaktiv"
 
 #: hypha/apply/users/templates/wagtailusers/users/results.html:7
 #, python-format
+#| msgid "There is %(counter)s match"
 msgid "There is %(counter)s match"
 msgid_plural "There are %(counter)s matches"
 msgstr[0] "Es gibt %(counter)s Treffer"
@@ -7841,71 +8157,66 @@ msgid "Page '{0}' can't be deleted because is in use in '{1}'."
 msgstr ""
 "Seite '{0}' kann nicht gelöscht werden, da sie in '{1}' verwendet wird."
 
-#: hypha/cookieconsent/templates/includes/banner.html:18
-#: hypha/cookieconsent/templates/includes/banner.html:66
-msgid "Decline tracking cookies."
-msgstr "Trackingcookies ablehnen."
-
-#: hypha/cookieconsent/templates/includes/banner.html:21
-#: hypha/cookieconsent/templates/includes/banner.html:69
-msgid "Essential only"
-msgstr "Nur Wesentliches"
-
-#: hypha/cookieconsent/templates/includes/banner.html:24
-#: hypha/cookieconsent/templates/includes/banner.html:72
-msgid "Accept tracking cookies."
-msgstr "Akzeptieren Sie Tracking-Cookies."
-
-#: hypha/cookieconsent/templates/includes/banner.html:27
-#: hypha/cookieconsent/templates/includes/banner.html:75
-msgid "Accept all"
-msgstr "Alle akzeptieren"
-
-#: hypha/cookieconsent/templates/includes/banner.html:30
-#: hypha/cookieconsent/templates/includes/banner.html:78
-msgid "Acknowledge use of essential cookies."
-msgstr "Bestätigung der Verwendung von essentiellen Cookies."
-
-#: hypha/cookieconsent/templates/includes/banner.html:32
-#: hypha/cookieconsent/templates/includes/banner.html:80
-msgid "Ok"
-msgstr "Ok"
-
-#: hypha/cookieconsent/templates/includes/banner.html:36
-msgid "Learn more about specific cookies used."
-msgstr "Erfahren Sie mehr über spezifische verwendete Cookies."
-
-#: hypha/cookieconsent/templates/includes/banner.html:38
-msgid "Learn More"
-msgstr "Erfahren Sie Mehr"
-
-#: hypha/cookieconsent/templates/includes/banner.html:46
+#: hypha/cookieconsent/templates/includes/banner.html:22
 msgid ""
-"This Website uses cookies.  Below you can select the categories of cookies "
-"to allow when you use our website and services."
+"This Website uses cookies. Below you can select the categories of cookies to "
+"allow when you use our website and services."
 msgstr ""
 "Diese Website verwendet Cookies. Unten können Sie die Kategorien von Cookies "
-"auswählen, die Sie zulassen möchten, wenn Sie unsere Website und Dienste "
-"nutzen."
+"auswählen, die Sie bei der Nutzung unserer Website und unserer "
+"Dienstleistungen erlauben."
 
-#: hypha/cookieconsent/templates/includes/banner.html:51
+#: hypha/cookieconsent/templates/includes/banner.html:31
 msgid "Essential Cookies"
 msgstr "Essenzielle Cookies"
 
-#: hypha/cookieconsent/templates/includes/banner.html:53
-msgid "Always enabled."
-msgstr "Immer aktiviert."
+#: hypha/cookieconsent/templates/includes/banner.html:33
+msgid "Always enabled"
+msgstr "Immer aktiviert"
 
-#: hypha/cookieconsent/templates/includes/banner.html:57
+#: hypha/cookieconsent/templates/includes/banner.html:44
 msgid "Analytics Cookies"
 msgstr "Analyse-Cookies"
 
-#: hypha/cookieconsent/templates/includes/banner.html:84
+#: hypha/cookieconsent/templates/includes/banner.html:58
+msgid "Decline tracking cookies."
+msgstr "Trackingcookies ablehnen."
+
+#: hypha/cookieconsent/templates/includes/banner.html:61
+msgid "Essential only"
+msgstr "Nur Wesentliches"
+
+#: hypha/cookieconsent/templates/includes/banner.html:65
+msgid "Accept all tracking cookies."
+msgstr "Akzeptieren Sie alle Tracking-Cookies."
+
+#: hypha/cookieconsent/templates/includes/banner.html:68
+msgid "Accept all"
+msgstr "Alle akzeptieren"
+
+#: hypha/cookieconsent/templates/includes/banner.html:72
+msgid "Acknowledge use of essential cookies."
+msgstr "Bestätigung der Verwendung von essentiellen Cookies."
+
+#: hypha/cookieconsent/templates/includes/banner.html:74
+msgid "Ok"
+msgstr "Ok"
+
+#: hypha/cookieconsent/templates/includes/banner.html:79
+msgid "Learn more about specific cookies used."
+msgstr "Erfahren Sie mehr über spezifische verwendete Cookies."
+
+#: hypha/cookieconsent/templates/includes/banner.html:83
+msgid "Learn More"
+msgstr "Erfahren Sie Mehr"
+
+#: hypha/cookieconsent/templates/includes/banner.html:89
 msgid "Return to main cookie menu."
 msgstr "Zurück zum Haupt-Cookie-Menü."
 
-#: hypha/cookieconsent/templates/includes/banner.html:87
-msgid "Back"
+#: hypha/cookieconsent/templates/includes/banner.html:94
+#: hypha/templates/403.html:22 hypha/templates/404.html:35
+msgid "Go Back"
 msgstr "Zurück"
 
 #: hypha/core/models/system_settings.py:24
@@ -7920,15 +8231,26 @@ msgstr "Untertitelung"
 msgid "The strapline to be displayed on the homepage."
 msgstr "Der Untertitel, der auf der Startseite angezeigt werden soll."
 
-#: hypha/core/models/system_settings.py:39
+#: hypha/core/models/system_settings.py:34
+msgid "No open applications message"
+msgstr "Keine offene Anwendungen-Meldung"
+
+#: hypha/core/models/system_settings.py:35
+msgid "The message to be displayed when there are no open applications."
+msgstr ""
+"Die Nachricht wird angezeigt, wenn keine offenen Anwendungen vorhanden sind."
+
+#: hypha/core/models/system_settings.py:45
 msgid "Default site logo"
 msgstr "Standard-Logo der Website"
 
-#: hypha/core/models/system_settings.py:48
-msgid "Mobil site logo (if not set default will be used)"
-msgstr "Mobil-Site-Logo (wenn nicht gesetzt, wird das Standard-Logo verwendet)"
+#: hypha/core/models/system_settings.py:54
+msgid "Mobile site logo (if not set default will be used)"
+msgstr ""
+"Das Logo der mobilen Seite (falls nicht standardmäßig gesetzt, wird "
+"verwendet)"
 
-#: hypha/core/models/system_settings.py:55
+#: hypha/core/models/system_settings.py:61
 msgid ""
 "Link for the site logo, e.g. \"https://www.example.org/\". If not set, "
 "defaults to page with slug set to \"home\"."
@@ -7936,7 +8258,7 @@ msgstr ""
 "Link zum Seitenlogo, z. B. \"https://www.example.org/\". Wenn nicht "
 "angegeben, wird standardmäßig die Seite mit dem Slug \"home\" verwendet."
 
-#: hypha/core/models/system_settings.py:62
+#: hypha/core/models/system_settings.py:68
 msgid ""
 "This will overwrite the default front page navigation bar, html tags is "
 "allowed."
@@ -7944,28 +8266,28 @@ msgstr ""
 "Dies wird die Standard-Navigationsleiste der Startseite überschreiben, "
 "<strong>HTML-Tags</strong> sind erlaubt."
 
-#: hypha/core/models/system_settings.py:70
+#: hypha/core/models/system_settings.py:76
 msgid "This will be added to the footer, html tags is allowed."
 msgstr ""
 "Dies wird dem Footer hinzugefügt, <a href=\"#\">HTML-Tags</a> sind erlaubt."
 
-#: hypha/core/navigation.py:33
+#: hypha/core/navigation.py:54
 msgid "My Dashboard"
 msgstr "Mein Dashboard"
 
-#: hypha/core/navigation.py:49
+#: hypha/core/navigation.py:70
 msgid "Rounds & Labs"
 msgstr "Runden & Labore"
 
-#: hypha/core/navigation.py:54
+#: hypha/core/navigation.py:75
 msgid "Staff Assignments"
 msgstr "Teamzuweisungen"
 
-#: hypha/core/navigation.py:64
+#: hypha/core/navigation.py:85
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: hypha/core/navigation.py:69
+#: hypha/core/navigation.py:90
 msgid "Staff flagged"
 msgstr "Vom Team gekennzeichnet"
 
@@ -7977,7 +8299,7 @@ msgstr "Zurück nach oben"
 msgid "Menu Item"
 msgstr "Menüpunkt"
 
-#: hypha/settings/django.py:161
+#: hypha/settings/django.py:165
 msgid ""
 "This password has previously appeared in a data breach and should not be "
 "used. Please choose a different password."
@@ -7985,31 +8307,129 @@ msgstr ""
 "Dieses Passwort ist bereits in einem Datenleak aufgetaucht und sollte nicht "
 "verwendet werden. Bitte wählen Sie ein anderes Passwort."
 
-#: hypha/settings/django.py:164
+#: hypha/settings/django.py:168
 msgid "Your password must not have been detected in a major security breach."
 msgstr ""
 "Ihr Passwort darf nicht in einem großen Sicherheitsvorfall entdeckt worden "
 "sein."
 
-#: hypha/templates/base-apply.html:40
+#: hypha/templates/400.html:8 hypha/templates/400.html:25
+msgid "Bad Request"
+msgstr "Fehlerhafte Anfrage"
+
+#: hypha/templates/400.html:28
+msgid ""
+"The request could not be understood by the server due to malformed syntax or "
+"invalid parameters. Please check your request and try again."
+msgstr ""
+"Die Anfrage konnte vom Server aufgrund fehlerhafter Syntax oder ungültiger "
+"Parameter nicht verstanden werden. Bitte überprüfen Sie Ihre Anfrage und "
+"versuchen Sie es erneut."
+
+#: hypha/templates/400.html:33 hypha/templates/403.html:33
+#: hypha/templates/404.html:46
+msgid "Go to homepage"
+msgstr "Gehe zur Startseite"
+
+#: hypha/templates/400.html:37
+msgid "Error code: Bad Request (400)"
+msgstr "Fehlercode: Schlechte Anfrage (400)"
+
+#: hypha/templates/403.html:28 hypha/templates/404.html:41
+msgid "Go to Dashboard"
+msgstr "Gehe zum Dashboard"
+
+#: hypha/templates/404.html:8
+msgid "Not Found (404)"
+msgstr "Nicht gefunden (404)"
+
+#: hypha/templates/404.html:51
+msgid "Error code: Not Found (404)"
+msgstr "Fehlercode: Nicht gefunden (404)"
+
+#: hypha/templates/base-apply.html:26
+msgid "Toggle color theme"
+msgstr "Farb-Schema umschalten"
+
+#: hypha/templates/base-apply.html:27 hypha/templates/base-apply.html:28
+#: hypha/templates/base-apply.html:29
+msgid "Toggle theme"
+msgstr "Schema umschalten"
+
+#: hypha/templates/base-apply.html:27 hypha/templates/base-apply.html:28
+#: hypha/templates/base-apply.html:29
+msgid "current theme"
+msgstr "Aktuelles Schema"
+
+#: hypha/templates/base-apply.html:32
+msgid "Toggle Light / Dark / Auto color theme"
+msgstr "Schalte Dunkel/Hell/Auto Farbschema um"
+
+#: hypha/templates/base-apply.html:54
 msgid "Menu"
 msgstr "Menü"
 
-#: hypha/templates/base-pdf.html:64
+#: hypha/templates/base-apply.html:76
+msgid "Copyright"
+msgstr "Urheberrecht"
+
+#: hypha/templates/base-apply.html:79
+msgid "Built with"
+msgstr "Erstellt mit"
+
+#: hypha/templates/base-apply.html:85
+msgid "Manage cookies"
+msgstr "Cookies verwalten"
+
+#: hypha/templates/base-pdf.html:80
 #, python-format
 msgid "Exported by %(export_user)s on %(export_date)s"
 msgstr "Exportiert von %(export_user)s am %(export_date)s"
 
-#: hypha/templates/django/forms/widgets/number.html:11
-msgid "This must be a number"
-msgstr "Dies muss eine Zahl sein"
+#: hypha/templates/cotton/modal/header.html:11
+msgid "Close Modal"
+msgstr "Modalfenster schließen"
+
+#: hypha/templates/cotton/pagination.html:9
+msgid "First"
+msgstr "Erstes"
+
+#: hypha/templates/cotton/pagination.html:12
+msgid "Previous"
+msgstr "Vorherige"
+
+#: hypha/templates/cotton/pagination.html:25
+msgid "Last"
+msgstr "Letzte"
+
+#: hypha/templates/django/forms/widgets/number.html:12
+msgid "* This must be a number"
+msgstr "* Das muss eine Zahl sein"
+
+#: hypha/templates/django/forms/widgets/password.html:17
+#: hypha/templates/django/forms/widgets/password.html:18
+msgid "Hide password"
+msgstr "Passwort ausblenden"
+
+#: hypha/templates/django/forms/widgets/password.html:17
+#: hypha/templates/django/forms/widgets/password.html:18
+msgid "Show password"
+msgstr "Passwort anzeigen"
+
+#: hypha/templates/django/forms/widgets/password.html:36
+msgid "Password is currently visible"
+msgstr "Das Passwort ist derzeit sichtbar"
+
+#: hypha/templates/django/forms/widgets/password.html:36
+msgid "Password is currently hidden"
+msgstr "Das Passwort ist derzeit versteckt"
 
 #: hypha/templates/includes/header-logo.html:13
 #: hypha/templates/includes/header-logo.html:14
 msgid "Hypha logo"
 msgstr "Hypha-Logo"
 
-#: hypha/templates/includes/hijack-bar.html:13
+#: hypha/templates/includes/hijack-bar.html:14
 #, python-format
 msgid ""
 "You are currently working on behalf of <strong class=\"font-bold\">%(user)s</"
@@ -8018,20 +8438,24 @@ msgstr ""
 "Sie arbeiten derzeit im Auftrag von <strong class=\"font-bold\">%(user)s</"
 "strong>"
 
-#: hypha/templates/includes/hijack-bar.html:27
+#: hypha/templates/includes/hijack-bar.html:25
 msgid "Release"
 msgstr "Veröffentlichung"
 
-#: hypha/templates/includes/language-switcher.html:6
-#: hypha/templates/includes/language-switcher.html:11
+#: hypha/templates/includes/language-switcher.html:8
+#: hypha/templates/includes/language-switcher.html:13
 msgid "Language switcher"
 msgstr "Umschalter für Sprachen"
 
-#: hypha/templates/includes/language-switcher.html:44
+#: hypha/templates/includes/language-switcher.html:43
+msgid "Switch Language"
+msgstr "Sprache ändern"
+
+#: hypha/templates/includes/language-switcher.html:61
 msgid "Set language"
 msgstr "Sprache festlegen"
 
-#: hypha/templates/includes/language-switcher.html:48
+#: hypha/templates/includes/language-switcher.html:67
 msgid "Can't switch language, only one language is active."
 msgstr "Kann die Sprache nicht umschalten, nur eine Sprache ist aktiv."
 
@@ -8072,15 +8496,15 @@ msgstr "Aktivitätsfeed"
 msgid "My flagged"
 msgstr "Meine Markierten"
 
-#: hypha/templates/includes/user_menu.html:83
+#: hypha/templates/includes/user_menu.html:84
 msgid "Release User"
 msgstr "Benutzer freigeben"
 
-#: hypha/templates/includes/user_menu.html:93
+#: hypha/templates/includes/user_menu.html:94
 msgid "Log out"
 msgstr "Abmelden"
 
-#: hypha/templates/includes/user_menu.html:103
+#: hypha/templates/includes/user_menu.html:104
 msgid " or Sign up"
 msgstr " oder Registrieren"
 


### PR DESCRIPTION
⚠️ This PR targets #15 and not the main branch, make sure you merge them in the right order ⚠️ 

* First I used `xls2po` from the `po-excel-translate` package (modified to make it work locally with uv) to get a `.po` file
* That po file was missing source files, so I ran `makemessages -l de` to update the sources
* I then ran the po file through `poedit`, fixing errors (translated placeholders, whitespace mismatch, ...)
* Then I manually mixed translated tailwind classes (`italic` became `kursiv`)