### PR TITLE
WG-29: Add CRON task to prune old docker images

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -44,4 +44,4 @@
     name: "prune old docker images"
     minute: "0"
     hour: "2"
-    job: "docker image prune --filter 'until=168h' --force"
+    job: "docker system prune --filter 'until=168h' --force"

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -38,3 +38,10 @@
     name: docker
     state: started
     enabled: yes
+
+- name: Set up CRON task to prune old images
+  ansible.builtin.cron:
+    name: "prune old docker images"
+    minute: "0"
+    hour: "2"
+    job: "docker image prune --filter 'until=168h' --force"


### PR DESCRIPTION
This should prevent the server from running out of disk space if we do too many deploys 😅 