### PR TITLE
WG-31: Fix missing [View all] button for reviews on application page

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -1006,6 +1006,10 @@ class ApplicationSubmission(
         dismissed = self.status in PHASES_MAPPING["dismissed"]["statuses"]
         return accepted or dismissed
 
+    @property
+    def has_any_reviews(self):
+        return self.reviews.filter(is_draft=False).exists()
+
     # Methods for accessing data on the submission
 
     def get_data(self):

--- a/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
@@ -42,7 +42,7 @@
             <div class="card-actions">
                 {% include 'review/includes/review_button.html' with submission=object class="grow" %}
 
-                {% if request.user.is_apply_staff and not object.reviews.exists %}
+                {% if request.user.is_apply_staff and object.has_any_reviews %}
                     <a
                         href="{% url 'apply:submissions:reviews:list' submission_pk=object.id %}"
                         class="btn btn-outline grow"


### PR DESCRIPTION
This seems to be a Hypha bug introduced with 9cfc791538a13aa222c59996666b00ba64ab09af.

## Testing steps

1. Create an application
2. Add a review
3. Open the application page as an admin. Observe that the [View all] button under "Reviews & Assignees" is present