### PR TITLE
WG-32: Don't allow reviewers to update their reviews after reviews are closed

### DIFF
--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -232,32 +232,18 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
         return self.created_at.date() < self.updated_at.date()
 
     def can_update(self, user):
-        if user.is_anonymous:
-            return False
         if user.is_apply_staff:
             return True
+        elif not user.is_reviewer:
+            return False
         submission_has_open_reviews = (
             self.submission.phase.name in PHASES_MAPPING["external-review"]["statuses"]
         )
         user_is_author = user == self.author.reviewer
-        user_has_update_permissions = user.has_perm("review.change_review")
-        return all(
-            [submission_has_open_reviews, user_is_author, user_has_update_permissions]
-        )
+        return submission_has_open_reviews and user_is_author
 
     def can_delete(self, user):
-        if user.is_anonymous:
-            return False
-        if user.is_apply_staff:
-            return True
-        submission_has_open_reviews = (
-            self.submission.phase.name in PHASES_MAPPING["external-review"]["statuses"]
-        )
-        user_is_author = user == self.author.reviewer
-        user_has_delete_permissions = user.has_perm("review.delete_review")
-        return all(
-            [submission_has_open_reviews, user_is_author, user_has_delete_permissions]
-        )
+        return self.can_update(user)
 
 
 class ReviewOpinion(models.Model):

--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -239,7 +239,7 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
         submission_has_open_reviews = (
             self.submission.phase.name in PHASES_MAPPING["external-review"]["statuses"]
         )
-        user_is_author = user == self.author
+        user_is_author = user == self.author.reviewer
         user_has_update_permissions = user.has_perm("review.change_review")
         return all(
             [submission_has_open_reviews, user_is_author, user_has_update_permissions]
@@ -253,7 +253,7 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
         submission_has_open_reviews = (
             self.submission.phase.name in PHASES_MAPPING["external-review"]["statuses"]
         )
-        user_is_author = user == self.author
+        user_is_author = user == self.author.reviewer
         user_has_delete_permissions = user.has_perm("review.delete_review")
         return all(
             [submission_has_open_reviews, user_is_author, user_has_delete_permissions]

--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -7,6 +7,7 @@ from wagtail.admin.panels import FieldPanel
 from wagtail.fields import StreamField
 
 from hypha.apply.funds.models.mixins import AccessFormData
+from hypha.apply.funds.workflows.constants import PHASES_MAPPING
 from hypha.apply.stream_forms.models import BaseStreamForm
 from hypha.apply.users.roles import (
     PARTNER_GROUP_NAME,
@@ -229,6 +230,34 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
     def is_updated(self):
         # Only compare dates, not time.
         return self.created_at.date() < self.updated_at.date()
+
+    def can_update(self, user):
+        if user.is_anonymous:
+            return False
+        if user.is_apply_staff:
+            return True
+        submission_has_open_reviews = (
+            self.submission.phase.name in PHASES_MAPPING["external-review"]["statuses"]
+        )
+        user_is_author = user == self.author
+        user_has_update_permissions = user.has_perm("review.change_review")
+        return all(
+            [submission_has_open_reviews, user_is_author, user_has_update_permissions]
+        )
+
+    def can_delete(self, user):
+        if user.is_anonymous:
+            return False
+        if user.is_apply_staff:
+            return True
+        submission_has_open_reviews = (
+            self.submission.phase.name in PHASES_MAPPING["external-review"]["statuses"]
+        )
+        user_is_author = user == self.author
+        user_has_delete_permissions = user.has_perm("review.delete_review")
+        return all(
+            [submission_has_open_reviews, user_is_author, user_has_delete_permissions]
+        )
 
 
 class ReviewOpinion(models.Model):

--- a/hypha/apply/review/templates/review/review_detail.html
+++ b/hypha/apply/review/templates/review/review_detail.html
@@ -1,5 +1,5 @@
 {% extends "base-apply.html" %}
-{% load i18n nh3_tags submission_tags heroicons %}
+{% load i18n nh3_tags review_tags submission_tags heroicons %}
 {% block title %}{% trans "Review for" %} {{ review.submission.title }}{% endblock %}
 
 {% block hero %}
@@ -73,7 +73,7 @@
 
         <aside class="flex flex-col gap-4 layout-sidebar">
             <div class="flex gap-3 justify-end items-start">
-                {% if not perms.funds.change_review or request.user == review.author.reviewer %}
+                {% if user|can_update_review:review %}
                     <a
                         class="btn btn-primary btn-sm"
                         href="{% url 'apply:submissions:reviews:edit' submission_pk=object.submission.id pk=object.id %}"
@@ -83,7 +83,7 @@
                     </a>
                 {% endif %}
 
-                {% if not perms.funds.delete_review or request.user == review.author.reviewer %}
+                {% if user|can_delete_review:review %}
                     <a
                         class="btn btn-error btn-outline btn-sm"
                         href="{% url 'apply:submissions:reviews:delete' submission_pk=object.submission.id pk=object.id %}"

--- a/hypha/apply/review/templatetags/review_tags.py
+++ b/hypha/apply/review/templatetags/review_tags.py
@@ -51,6 +51,16 @@ def has_draft(user, submission):
 
 
 @register.filter
+def can_update_review(user, review):
+    return review.can_update(user=user)
+
+
+@register.filter
+def can_delete_review(user, review):
+    return review.can_delete(user=user)
+
+
+@register.filter
 def average_review_score(reviewers):
     if reviewers:
         scores = [


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/WG-32

## Testing notes

1. [as Applicant] Submit application
2. [as Staff] Assign reviewer 1, open reviews
3. [as Reviewer 1] Submit review
5. [as Reviewer 1] Visit application page, view review. Observe that both a "edit" and "delete" buttons are present
4. [as Staff] Close reviews
5. [as Reviewer 1] Visit application page, view review. Observe that both a "edit" and "delete" buttons are absent