### PR TITLE
WG-38: Let reviewers abstain even if review form has required fields

### DIFF
--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -231,6 +231,7 @@ class ReviewAbstainView(ReviewCreateOrUpdateView):
             elif isinstance(field.block, ScoreFieldWithoutTextBlock):
                 # for ScoreFieldWithoutTextBlock the blank value is NA:
                 form_field.initial = ""
+                form_field.required = False
             elif isinstance(field.block, ScoreFieldBlock):
                 form_field.initial = [_("Abstain"), NA]
             else:

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -222,7 +222,9 @@ class ReviewAbstainView(ReviewCreateOrUpdateView):
         for field in self.get_defined_fields():
             form_field = form.fields[field.id]
 
-            if isinstance(field.block, RecommendationCommentsBlock):
+            if isinstance(field.block, VisibilityBlock):
+                pass
+            elif isinstance(field.block, RecommendationCommentsBlock):
                 form_field.initial = _("Abstain")
             elif isinstance(field.block, RecommendationBlock):
                 form_field.initial = MAYBE
@@ -231,6 +233,8 @@ class ReviewAbstainView(ReviewCreateOrUpdateView):
                 form_field.initial = ""
             elif isinstance(field.block, ScoreFieldBlock):
                 form_field.initial = [_("Abstain"), NA]
+            else:
+                form_field.required = False
 
             if isinstance(field.block, VisibilityBlock):
                 pass


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/WG-38

## Testing steps

1. [Admin] Create a review form with an optional "rich text field", mark that field as "required"
2. [Admin] Create a Fund with the workflow "DH Idea & Concept", then create a round for that fund
3. [Applicant] Submit an application for that round
4. [Admin] Assign reviewers, then open reviews
5. [Reviewer] On the application page, click "i abstain", then confirm the form submission. Observe that no errors are show and that the abstention has been correctly recoreded