### PR TITLE
WG-37: Don't let staff users review applications

### DIFF
--- a/hypha/apply/funds/workflows/definitions/DH_idea_concept.py
+++ b/hypha/apply/funds/workflows/definitions/DH_idea_concept.py
@@ -6,7 +6,7 @@ from ..permissions import (
     applicant_edit_permissions,
     default_permissions,
     no_permissions,
-    reviewer_review_permissions,
+    reviewer_only_review_permissions,
     staff_edit_permissions,
 )
 
@@ -66,7 +66,7 @@ DHIdeaConceptDefinition = [
             },
             "display": _("External Review"),
             "stage": DHIdea,
-            "permissions": reviewer_review_permissions,
+            "permissions": reviewer_only_review_permissions,
         },
     },
     {
@@ -163,7 +163,7 @@ DHIdeaConceptDefinition = [
             },
             "display": _("External Review"),
             "stage": DHConcept,
-            "permissions": reviewer_review_permissions,
+            "permissions": reviewer_only_review_permissions,
         },
     },
     {

--- a/hypha/apply/funds/workflows/permissions.py
+++ b/hypha/apply/funds/workflows/permissions.py
@@ -53,6 +53,9 @@ hidden_from_applicant_permissions = make_permissions(
 reviewer_review_permissions = make_permissions(
     edit=[staff_can], review=[staff_can, reviewer_can]
 )
+reviewer_only_review_permissions = make_permissions(
+    edit=[staff_can], review=[reviewer_can]
+)
 community_review_permissions = make_permissions(
     edit=[staff_can], review=[staff_can, reviewer_can, community_can]
 )


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/WG-37

## Testing steps

1. [Admin] Create fund with workflow "DH Idea & Concept"
2. [Applicant] Submit application
3. [Admin] Open reviews, observe that there's no "Add review" button (or "I abstain" for that matter)