### PR TITLE
WG-35: Remove duplicate determination choices in form

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -296,7 +296,7 @@ class AddTransitions(models.base.ModelBase):
     def __new__(cls, name, bases, attrs, **kwargs):
         status_field = attrs.get("status_field")
 
-        for workflow in WORKFLOWS.values():
+        for workflow_id, workflow in WORKFLOWS.items():
             for phase_name, data in workflow.items():
                 for transition_name, action in data.transitions.items():
                     method_name = transition_id(transition_name, data)
@@ -328,13 +328,18 @@ class AddTransitions(models.base.ModelBase):
                         attrs[condition] for condition in action.get("conditions", [])
                     ]
 
+                    custom = {
+                        "workflow_id": workflow_id,
+                        **action.get("custom", {}),
+                    }
+
                     # Create the transition
                     transition_func = status_field.transition(
                         source=phase_name,
                         target=transition_name,
                         permission=permission_func,
                         conditions=conditions,
-                        custom=action.get("custom", {}),
+                        custom=custom,
                     )
 
                     # Bind the transition method
@@ -349,6 +354,17 @@ class AddTransitions(models.base.ModelBase):
 
         attrs["get_transition"] = get_transition
 
+        def is_transition_valid_for_workflow(self, transition):
+            submission_workflow_id = self.workflow.admin_name
+            transition_workflow_id = transition.custom.get("workflow_id")
+
+            return (
+                transition_workflow_id is None
+                or transition_workflow_id == submission_workflow_id
+            )
+
+        attrs["is_transition_valid_for_workflow"] = is_transition_valid_for_workflow
+
         def get_actions_for_user(self, user):
             transitions = type(self).status_field.get_available_transitions(
                 self, self.status, user
@@ -360,6 +376,7 @@ class AddTransitions(models.base.ModelBase):
                 )
                 for transition in transitions
                 if self.get_transition(transition.target)
+                and self.is_transition_valid_for_workflow(transition)
             ]
             yield from actions
 


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/WG-35

After much digging, it turns out that this problem is fairly deep inside the submission wokflow logic and the duplicated choices were a symptom of a larger issue.
Hypha uses's the `viewflow` library (which was called `fsm` before) to handle the transitions between workflow stages. But because a `Submission`'s possible stages must be declared on the model (and thus doesn't know about which actual workflow the submission is using), the `viewflow` state is initialized with all possible stages across all possible workflows.
This creates a problem when listing the possible next stages for a given submission based on its current stage, since possible next stage then can include stages from a different workflow that the submission's current workflow (determined by the fund).

The fix was therefore to make the `ApplicationSubmission.get_actions_for_user()` method only list actions that are relevant to the submission's workflow.

## Testing notes

1. [Applicant] submit an application to a fund that uses the "DH Idea & Concept" workflow
2. [Admin] Progress the application to the determination stage of the "Concept" phase (second phase)
3. [Admin] Go to the [Add Determination] form, observe that the choices in the "Determination" dropdown don't include duplicate entries.