### PR TITLE
WG-22: Interface colors

### DIFF
--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext as _
 
 from hypha.apply.activity.models import ALL, APPLICANT, TEAM
 from hypha.apply.activity.options import MESSAGES
-from hypha.apply.funds.workflows.constants import PHASE_BG_COLORS
+from hypha.apply.funds.workflows.constants import get_phase_bg_color
 from hypha.apply.projects.utils import (
     get_invoice_public_status,
     get_invoice_status_display_value,
@@ -223,7 +223,7 @@ class ActivityAdapter(AdapterBase):
 
     def handle_transition(self, new_phase, source, old_phase=None, **kwargs):
         def wrap_in_color_class(text):
-            color_class = PHASE_BG_COLORS.get(text, "")
+            color_class = get_phase_bg_color(text, default="")
             return f'<span class="rounded-full inline-block px-2 py-0.5 font-medium text-gray-800 {color_class}">{text}</span>'
 
         submission = source

--- a/hypha/apply/dashboard/templates/dashboard/includes/project_status_bar.html
+++ b/hypha/apply/dashboard/templates/dashboard/includes/project_status_bar.html
@@ -5,7 +5,7 @@
         {% for status, display_text in statuses %}
             {% if forloop.counter0 == current_status_index %}
                 <li data-content="●" class="step step-primary">
-                    <span class="block py-1 px-2 text-xs font-semibold rounded-box bg-primary text-primary-content row-start-auto!">{{ display_text }}</span>
+                    <span class="block py-1 px-2 text-xs font-semibold rounded-box text-primary-content row-start-auto!">{{ display_text }}</span>
                 </li>
             {% elif forloop.counter0 < current_status_index %}
                 <li data-content="✓" class="step step-primary">{{ display_text }}</li>

--- a/hypha/apply/funds/templates/funds/includes/status_bar.html
+++ b/hypha/apply/funds/templates/funds/includes/status_bar.html
@@ -7,7 +7,7 @@
                 {% status_display current_phase phase public as display_text %}
                 {% if current_phase.step == phase.step %}
                     <li data-content="●" class="step step-primary">
-                        <span class="block py-1 px-2 text-xs font-semibold rounded-box bg-primary text-primary-content row-start-auto!">{{ display_text }}</span>
+                        <span class="block py-1 px-2 text-xs font-semibold rounded-box text-primary-content row-start-auto!">{{ display_text }}</span>
                     </li>
                 {% elif current_phase.step > phase.step %}
                     <li data-content="✓" class="step step-primary">{{ display_text }}</li>

--- a/hypha/apply/funds/templates/submissions/all.html
+++ b/hypha/apply/funds/templates/submissions/all.html
@@ -146,24 +146,24 @@
             </label>
 
             {% if can_view_archive %}
-                <label class="label">
+                <label class="label {% if show_archived %}text-accent{% else %}text-neutral{% endif %}">
                     <input
                         type="checkbox"
                         name="archived"
                         {% if show_archived %}checked{% endif %}
-                        class="toggle toggle-sm toggle-primary"
+                        class="toggle toggle-sm {% if show_archived %}toggle-accent{% else %}toggle-neutral{% endif %}"
                     >
                     {% trans "Archived" %}
                 </label>
             {% endif %}
 
             {% if can_access_drafts %}
-                <label class="label">
+                <label class="label {% if show_drafts %}text-accent{% else %}text-neutral{% endif %}">
                     <input
                         type="checkbox"
                         name="drafts"
                         {% if show_drafts %}checked{% endif %}
-                        class="toggle toggle-sm toggle-primary"
+                        class="toggle toggle-sm {% if show_drafts %}toggle-accent{% else %}toggle-neutral{% endif %}"
                     >
                     {% trans "Drafts" %}
                 </label>

--- a/hypha/apply/funds/workflows/constants.py
+++ b/hypha/apply/funds/workflows/constants.py
@@ -11,21 +11,24 @@ from .utils import (
 DRAFT_STATE = "draft"
 INITIAL_STATE = "in_discussion"
 
-PHASE_BG_COLORS = {
-    "Draft": "bg-gray-200",
-    "Accepted": "bg-green-200",
-    "Idea Accepted": "bg-green-200",
-    "Need screening": "bg-cyan-200",
-    "Ready for Determination": "bg-blue-200",
-    "Ready For Discussion": "bg-blue-100",
-    "Invited for Proposal": "bg-green-100",
-    "Invited for Concept": "bg-green-100",
-    "Internal Review": "bg-yellow-200",
-    "External Review": "bg-yellow-200",
-    "More information required": "bg-yellow-200",
-    "Accepted but additional info required": "bg-green-100",
-    "Dismissed": "bg-rose-200",
-}
+
+def get_phase_bg_color(phase, default="bg-gray-200"):
+    colors = {
+        _("Draft"): "bg-gray-200",
+        _("Accepted"): "bg-green-200",
+        _("Idea Accepted"): "bg-green-200",
+        _("Need screening"): "bg-cyan-200",
+        _("Ready for Determination"): "bg-blue-200",
+        _("Ready For Discussion"): "bg-blue-100",
+        _("Invited for Proposal"): "bg-green-100",
+        _("Invited for Concept"): "bg-green-100",
+        _("Internal Review"): "bg-yellow-200",
+        _("External Review"): "bg-yellow-200",
+        _("More information required"): "bg-yellow-200",
+        _("Accepted but additional info required"): "bg-green-100",
+        _("Dismissed"): "bg-rose-200",
+    }
+    return colors.get(phase, default)
 
 
 class UserPermissions(Enum):

--- a/hypha/apply/funds/workflows/models/phase.py
+++ b/hypha/apply/funds/workflows/models/phase.py
@@ -1,6 +1,6 @@
 from django.utils.text import slugify
 
-from ..constants import PHASE_BG_COLORS, UserPermissions
+from ..constants import UserPermissions, get_phase_bg_color
 from ..permissions import Permissions
 
 
@@ -33,7 +33,7 @@ class Phase:
 
         self.public_name = public or self.display_name
         self.future_name_staff = future or self.display_name
-        self.bg_color = PHASE_BG_COLORS.get(self.display_name, "bg-gray-200")
+        self.bg_color = get_phase_bg_color(self.display_name)
         self.future_name_public = future or self.public_name
         self.stage = stage
         self.permissions = Permissions(permissions)

--- a/hypha/home/templates/home/includes/fund-list-item.html
+++ b/hypha/home/templates/home/includes/fund-list-item.html
@@ -16,7 +16,7 @@
       {% endif %}
     </h2>
     {% if page.next_deadline and page.show_deadline %}
-      <p class="badge badge-info badge-soft badge-md">
+      <p class="badge badge-accent badge-soft badge-md">
         {% heroicon_micro 'calendar-days' class='size-4' aria_hidden=true %}
         <span class="font-medium">{% trans 'Next deadline' %}: {{ page.next_deadline|date:'M j, Y' }}</span>
       </p>

--- a/hypha/static_src/tailwind/base/themes.css
+++ b/hypha/static_src/tailwind/base/themes.css
@@ -42,6 +42,8 @@
     from var(--color-brand) 100%
       calc(var(--color-brand-base) + (sin(0.1 * pi) * c)) h
   );
+  --color-dh-blue: oklch(0.319 0.156 263);
+  --color-dh-magenta: oklch(0.597 0.241 2);
 }
 
 @plugin "daisyui/theme" {
@@ -53,7 +55,7 @@
   --color-base-200: oklch(23.26% 0.014 253.1);
   --color-base-300: oklch(21.15% 0.012 254.09);
   --color-base-content: oklch(97.807% 0.029 256.847);
-  --color-primary: var(--color-brand-50);
+  --color-primary: var(--color-dh-blue);
   --color-primary-content: oklch(88.34% 0.019 251.473);
   --color-secondary: oklch(64.092% 0.027 229.389);
   --color-secondary-content: oklch(12.818% 0.005 229.389);
@@ -89,7 +91,7 @@
   --color-base-200: oklch(98% 0 0);
   --color-base-300: oklch(95% 0 0);
   --color-base-content: oklch(22.389% 0.031 278.072);
-  --color-primary: var(--color-brand-60);
+  --color-primary: var(--color-dh-blue);
   --color-primary-content: oklch(100% 0 0);
   --color-secondary: oklch(55% 0.046 257.417);
   --color-secondary-content: oklch(100% 0 0);

--- a/hypha/static_src/tailwind/base/themes.css
+++ b/hypha/static_src/tailwind/base/themes.css
@@ -59,7 +59,7 @@
   --color-primary-content: oklch(88.34% 0.019 251.473);
   --color-secondary: oklch(64.092% 0.027 229.389);
   --color-secondary-content: oklch(12.818% 0.005 229.389);
-  --color-accent: oklch(67.271% 0.167 35.791);
+  --color-accent: var(--color-dh-magenta);
   --color-accent-content: oklch(13.454% 0.033 35.791);
   --color-neutral: oklch(10% 0 0);
   --color-neutral-content: oklch(85.488% 0.002 253.041);
@@ -95,7 +95,7 @@
   --color-primary-content: oklch(100% 0 0);
   --color-secondary: oklch(55% 0.046 257.417);
   --color-secondary-content: oklch(100% 0 0);
-  --color-accent: oklch(60% 0.118 184.704);
+  --color-accent: var(--color-dh-magenta);
   --color-accent-content: oklch(100% 0 0);
   --color-neutral: oklch(0% 0 0);
   --color-neutral-content: oklch(100% 0 0);

--- a/hypha/static_src/tailwind/components/steps.css
+++ b/hypha/static_src/tailwind/components/steps.css
@@ -10,3 +10,12 @@
     @apply size-7;
   }
 }
+
+.steps .step-primary + .step-primary::before,
+.steps .step-primary::after,
+.steps .step-primary > .step-icon {
+  --step-bg: var(--color-dh-magenta);
+}
+.steps .step-primary span {
+  background-color: var(--color-dh-magenta);
+}

--- a/hypha/static_src/tailwind/components/tinymce.css
+++ b/hypha/static_src/tailwind/components/tinymce.css
@@ -45,14 +45,14 @@
 
   .tox-statusbar__wordcount.word-count-warning,
   .tox-statusbar__wordcount.word-count-warning-2 {
-    background-color: var(--color-warning);
-    color: var(--color-warning-content);
-    font-weight: bold;
+    background-color: var(--color-warning) !important;
+    color: var(--color-warning-content) !important;
+    font-weight: bold !important;
   }
 
   .tox-statusbar__wordcount.word-count-warning-2 {
-    background-color: var(--color-error);
-    color: var(--color-error-content);
+    background-color: var(--color-error) !important;
+    color: var(--color-error-content) !important;
   }
 
   .tox-statusbar a,


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/WG-22

I've done 1 commit per subtask on the ticket (with WG-44 having an extra `fixup` commit after feedback from Anja).

## Testing notes:

* WG-41: Check that the color of the primary buttons/links/... is now the DH blue
* WG-42: Check that the status timeline uses the DH magenta (on an application page and on an applicant's dashboard)
* WG-44: Check the "archived" and "drafts" toggle on the submission list
* WG-46: Create a Fund + Round that has an application form with a rich text field that has a word limit of 50. Go to the application page and insert > 50 words in the field, check the color of the error message
* WG-43: Create multiple applications with various statuses. Go to the submission list, observe the colors of the status badges is different based on the status
* WG-40: Create a round with a dealdine, check the color of the deadline badge on the homepage