### PR TITLE
WG-48: Fix incorrect paragraph in application confirmation email

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -1074,6 +1074,8 @@ class ApplicationSubmission(
                 remove_tasks_for_user(
                     code=SUBMISSION_DRAFT, user=by, related_obj=instance
                 )
+                # Workaround for issue https://github.com/HyphaApp/hypha/issues/4678:
+                instance.status = target
                 # notify for a new submission
                 messenger(
                     MESSAGES.NEW_SUBMISSION,


### PR DESCRIPTION
1. Open application form, fill in required data
2. Press [Preview and submit] (in german "Vorschau und senden")
3. Press [Submit for review] ("Zur Bewertung einreichen")
4. Observe that the confirmation email contains the sentence "We will review and reply to your submission as quickly as possible." ("Wir werden Ihre Einreichung überprüfen und so schnell wie möglich antworten.") and not "Please note that it is not submitted for review because it's still in draft." (""Bitte beachten Sie, dass diese noch nicht zur finalen Bewertung freigegeben wurde, da sie sich noch im Entwurfsstadium befindet."")
