### PR TITLE
Don't hardcode login/signup URL in user menu

### DIFF
--- a/ansible/roles/hypha/templates/local_settings.py.jinja2
+++ b/ansible/roles/hypha/templates/local_settings.py.jinja2
@@ -18,3 +18,6 @@ CURRENCY_LOCALE = "de"
 LANGUAGES = [("de", "Deutsch")]
 LANGUAGE_CODE = "de"
 LANGUAGE_SWITCHER = False
+
+# LOGIN_URL = "users:login"  # email + password
+# LOGIN_URL = "users:passwordless_login_signup"  # email only (default)

--- a/hypha/core/context_processors.py
+++ b/hypha/core/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.shortcuts import resolve_url
 
 from hypha.home.models import ApplyHomePage
 
@@ -23,4 +24,5 @@ def global_vars(request):
         "SUBMISSIONS_TABLE_EXCLUDED_FIELDS": settings.SUBMISSIONS_TABLE_EXCLUDED_FIELDS,
         "HIJACK_ENABLE": settings.HIJACK_ENABLE,
         "LANGUAGE_SWITCHER": settings.LANGUAGE_SWITCHER,
+        "LOGIN_URL": resolve_url(settings.LOGIN_URL),
     }

--- a/hypha/templates/includes/user_menu.html
+++ b/hypha/templates/includes/user_menu.html
@@ -98,7 +98,7 @@
 {% else %}
     <a
         class="btn btn-outline btn-secondary"
-        href="{{ APPLY_SITE.root_url }}{% url 'users:passwordless_login_signup' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}"
+        href="{{ APPLY_SITE.root_url }}{{ LOGIN_URL }}{% if redirect_url %}?next={{ redirect_url }}{% endif %}"
     >
         {% heroicon_micro "user" class="inline align-text-bottom size-4 me-1" aria_hidden=true %}
         {% trans "Log in" %} {% if ENABLE_PUBLIC_SIGNUP %} {% trans " or Sign up" %} {% endif %}


### PR DESCRIPTION
With this change, it's now possible to change the
URL used for the login/signup button by changing
settings.LOGIN_URL.

Refs [WG-56](https://torchbox.atlassian.net/browse/WG-56)