### PR TITLE
WG-62: Set up celery + redis on staging/prod servers

### DIFF
--- a/ansible/roles/hypha/defaults/main.yml
+++ b/ansible/roles/hypha/defaults/main.yml
@@ -25,5 +25,8 @@ hypha_docker_tag: "wtsh-main"
 # The postgres version used
 hypha_postgres_version: 16
 
+# The redis version used (for celery)
+hypha_redis_version: "8.4"
+
 # The name of the system user that can deploy the site (used in github action)
 hypha_deploy_user: deploy-{{ app_name }}

--- a/ansible/roles/hypha/tasks/main.yml
+++ b/ansible/roles/hypha/tasks/main.yml
@@ -35,6 +35,8 @@
   loop:
     - web
     - db
+    - redis
+    - celery
 
 - name: Enable systemd service {{ hypha_project_name }}-{{ item }}
   ansible.builtin.systemd:
@@ -43,11 +45,16 @@
   loop:
     - web
     - db
+    - redis
+    - celery
 
-- name: Start service {{ hypha_project_name }}-db
+- name: Start service {{ hypha_project_name }}-{{ item }}
   ansible.builtin.systemd:
-    name: "{{ hypha_project_name }}-db"
+    name: "{{ hypha_project_name }}-{{ item }}"
     state: started
+  loop:
+    - db
+    - redis
 
 - name: Make sure .env file exists
   ansible.builtin.template:

--- a/ansible/roles/hypha/tasks/main.yml
+++ b/ansible/roles/hypha/tasks/main.yml
@@ -26,7 +26,7 @@
     state: link
   notify: Restart nginx
 
-- name: Create systemd unit file {{ hypha_project_name }}-{{ item }}
+- name: Create systemd unit files {{ hypha_project_name }}
   ansible.builtin.template:
     src: systemd/{{ item }}.service.jinja2
     dest: /etc/systemd/system/{{ hypha_project_name }}-{{ item }}.service
@@ -38,7 +38,7 @@
     - redis
     - celery
 
-- name: Enable systemd service {{ hypha_project_name }}-{{ item }}
+- name: Enable systemd services {{ hypha_project_name }}
   ansible.builtin.systemd:
     name: "{{ hypha_project_name }}-{{ item }}"
     enabled: true
@@ -48,7 +48,7 @@
     - redis
     - celery
 
-- name: Start service {{ hypha_project_name }}-{{ item }}
+- name: Start services {{ hypha_project_name }}
   ansible.builtin.systemd:
     name: "{{ hypha_project_name }}-{{ item }}"
     state: started

--- a/ansible/roles/hypha/templates/deploy.sh.jinja2
+++ b/ansible/roles/hypha/templates/deploy.sh.jinja2
@@ -3,6 +3,7 @@ set -euo pipefail
 
 CONTAINER_WEB={{hypha_project_name}}-web
 SERVICE_WEB={{hypha_project_name}}-web
+SERVICE_CELERY={{hypha_project_name}}-celery
 IMAGE={{hypha_docker_image}}{% if hypha_docker_tag %}:{{ hypha_docker_tag }}{% endif +%}
 LOGFILE="{{ hypha_root_dir }}/deploy_$(date --iso).log"
 
@@ -28,7 +29,11 @@ systemctl daemon-reload
 
 echolog "Restarting service $SERVICE_WEB..."
 systemctl restart $SERVICE_WEB
-echolog "Service restarted. Sleeping for a bit..."
+
+echolog "Restarting celery $SERVICE_CELERY..."
+systemctl restart $SERVICE_CELERY
+
+echolog "Services restarted. Sleeping for a bit..."
 sleep 5
 echolog "Done."
 

--- a/ansible/roles/hypha/templates/hypha.env.jinja2
+++ b/ansible/roles/hypha/templates/hypha.env.jinja2
@@ -4,6 +4,10 @@ SECRET_KEY="{{ lookup('community.general.random_string', length=50) }}"
 ALLOWED_HOSTS={{ hypha_external_domain }}
 PRIMARY_HOST={{ hypha_external_domain }}
 DATABASE_URL="postgres://hypha@{{ hypha_project_name }}-db/hypha"
+REDIS_URL="redis://{{ hypha_project_name }}-redis:6379"
+
+# Activate background tasks:
+CELERY_TASK_ALWAYS_EAGER=0
 
 
 # Enable basic auth out of the box

--- a/ansible/roles/hypha/templates/systemd/celery.service.jinja2
+++ b/ansible/roles/hypha/templates/systemd/celery.service.jinja2
@@ -3,10 +3,10 @@ Description=Hypha celery docker container ({{ app_name }})
 After=docker.service
 Wants=network-online.target docker.socket
 Requires=docker.socket
-
-[Service]
 # Automatically restart this unit when web is restarted:
 PartOf={{ hypha_project_name }}-web
+
+[Service]
 Restart=on-failure
 ExecStart=/usr/bin/docker run \
     --name {{ hypha_project_name }}-celery \

--- a/ansible/roles/hypha/templates/systemd/celery.service.jinja2
+++ b/ansible/roles/hypha/templates/systemd/celery.service.jinja2
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/docker run \
     --volume {{ hypha_root_dir }}/media:/app/media \
     --mount type=bind,src={{ hypha_root_dir }}/hypha.env,dst=/app/.env,ro \
     --mount type=bind,src={{ hypha_root_dir }}/local_settings.py,dst=/app/hypha/settings/local.py,ro \
-    {{ hypha_docker_image }}{% if hypha_docker_tag %}:{{ hypha_docker_tag }}{% endif +%}
+    {{ hypha_docker_image }}{% if hypha_docker_tag %}:{{ hypha_docker_tag }}{% endif +%} \
     python -m celery --app=hypha.celery worker --loglevel=INFO --autoscale=6,2
 ExecStop=/usr/bin/docker container stop \
     --timeout 10 \

--- a/ansible/roles/hypha/templates/systemd/celery.service.jinja2
+++ b/ansible/roles/hypha/templates/systemd/celery.service.jinja2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Hypha celery docker container ({{ app_name }})
+After=docker.service
+Wants=network-online.target docker.socket
+Requires=docker.socket
+
+[Service]
+# Automatically restart this unit when web is restarted:
+PartOf={{ hypha_project_name }}-web
+Restart=on-failure
+ExecStart=/usr/bin/docker run \
+    --name {{ hypha_project_name }}-celery \
+    --pull never \
+    --rm \
+    --env PYTHONDONTWRITEBYTECODE=1 \
+    --env PYTHONUNBUFFERED=1 \
+    --network {{ hypha_docker_network }} \
+    --volume {{ hypha_root_dir }}/media:/app/media \
+    --mount type=bind,src={{ hypha_root_dir }}/hypha.env,dst=/app/.env,ro \
+    --mount type=bind,src={{ hypha_root_dir }}/local_settings.py,dst=/app/hypha/settings/local.py,ro \
+    {{ hypha_docker_image }}{% if hypha_docker_tag %}:{{ hypha_docker_tag }}{% endif +%}
+    python -m celery --app=hypha.celery worker --loglevel=INFO --autoscale=6,2
+ExecStop=/usr/bin/docker container stop \
+    --timeout 10 \
+    {{ hypha_project_name }}-celery
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/hypha/templates/systemd/redis.service.jinja2
+++ b/ansible/roles/hypha/templates/systemd/redis.service.jinja2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Hypha redis docker container ({{ app_name }})
+After=docker.service
+Wants=network-online.target docker.socket
+Requires=docker.socket
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/bin/docker run \
+    --name {{ hypha_project_name }}-redis \
+    --pull missing \
+    --rm \
+    --network {{ hypha_docker_network }} \
+    redis:{{ hypha_redis_version }}
+ExecStop=/usr/bin/docker container stop \
+    --timeout 10 \
+    {{ hypha_project_name }}-redis
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Ticket: [WG-62](https://torchbox.atlassian.net/browse/WG-62)


I've tested the ansible playbook on a local vagrant machine (see `ansible/README.md`) and it appears to work. Here's the inventory file (`ansible/inventory-vagrant.yml`):
```
---
production:
  hosts:
    wtsh-prod.localhost:
      app_name: wtsh-prod
      hypha_docker_tag: latest
      hypha_host_port: 9001
      hypha_deploy_user: deploy_prod
      ansible_port: 2222
      ansible_user: vagrant
      ansible_ssh_private_key_file: .vagrant/machines/default/virtualbox/private_key

staging:
  hosts:
    wtsh-staging.localhost:
      app_name: wtsh-staging
      hypha_docker_tag: wtsh-staging
      hypha_host_port: 9002
      hypha_deploy_user: deploy_staging
      ansible_port: 2222
      ansible_user: vagrant
      ansible_ssh_private_key_file: .vagrant/machines/default/virtualbox/private_key
```
Then ran the following:
* `cd ansible`
* `vagrant up` to create the virtual machine
* `uvx --from ansible ansible-playbook -i inventory-vagrant.yml -l staging setup.yml` to run the playbook
* `ssh vagrant@wtsh-staging.localhost -p 2222 -i .vagrant/machines/default/virtualbox/private_key` to connect to the vagrant machine
* `sudo su` to switch to the root user
* `/srv/wtsh-staging-hypha/deploy.sh` to run the deploy script (which will start/restart the web and celery containers)