### PR TITLE
Allow users with no roles to apply

### DIFF
--- a/hypha/apply/funds/templatetags/workflow_tags.py
+++ b/hypha/apply/funds/templatetags/workflow_tags.py
@@ -31,7 +31,7 @@ def has_review_perm(user, submission):
 
 @register.filter
 def can_apply(user):
-    return user.is_anonymous or user.is_applicant
+    return user.is_anonymous or user.is_applicant or user.roles == []
 
 
 @register.filter


### PR DESCRIPTION
Without this, brand new users were not able to apply because users are created without any roles.

This breakage was introduced by the feature from [WG-34](https://torchbox.atlassian.net/browse/WG-34)